### PR TITLE
Some changes on iCalImport.php

### DIFF
--- a/component/site/libraries/iCalImport.php
+++ b/component/site/libraries/iCalImport.php
@@ -82,7 +82,7 @@ class iCalImport
 					curl_setopt($ch, CURLOPT_HTTPAUTH, CURLAUTH_DIGEST);
 				}
 				
-				curl_setopt($ch, CURLOPT_URL,($isFile?"file://":"").$file);
+				curl_setopt($ch, CURLOPT_URL, $file);
 				curl_setopt($ch, CURLOPT_VERBOSE, 1);
 				curl_setopt($ch, CURLOPT_POST, 0);
 				curl_setopt($ch, CURLOPT_RETURNTRANSFER,1);


### PR DESCRIPTION
1. Set curl option CURLOPT_HTTPAUTH, if the iCal import url includes user name and password. e.g. http://username:password@www.example.com/cal.ics
2. Removed some code because it is unneeded. The variable $isFile cannot be true at this position. See line 74.
