### PR TITLE
Minor JS issues

### DIFF
--- a/component/admin/assets/js/editdefaults.js
+++ b/component/admin/assets/js/editdefaults.js
@@ -40,9 +40,10 @@ defaultsEditorPlugin = {
 		// reset the selected element back to 'Select...'
 		$(pluginNode).selectedIndex = 0;
 		// needed for MSIE 9 bug - see $(pluginNode)
-		jQuery.each($(pluginNode).options, function(option){
-			option.selected = false;
-		});
+                                    for (var i=0; i<sel.length; i++){
+                                        sel.options[i].selected = false;
+                                    }
+                                    var test = $(pluginNode).options;
 		return false;
 	}
 }


### PR DESCRIPTION
I'm not sure why, but the $ operator is giving an error for the each method. It seems that it's not understanding mootools way, but jQuery in no-conflict mode.
