### PR TITLE
adding option to set user to latest events module instead of getting session data

### DIFF
--- a/component/site/libraries/dbmodel.php
+++ b/component/site/libraries/dbmodel.php
@@ -516,8 +516,17 @@ class JEventsDBModel
 	{
 		//list($usec, $sec) = explode(" ", microtime());
 		//$starttime = (float) $usec + (float) $sec;
-
-		$user = JFactory::getUser();
+            
+                $userid = JRequest::getVar('jev_userid',"0");
+                
+                if($userid=="0")
+                {
+                    $user = JFactory::getUser();
+                }
+                else
+                {
+                    $user = JFactory::getUser($userid);
+                }
 		$lang = & JFactory::getLanguage();
 		$langtag = $lang->getTag();
 


### PR DESCRIPTION
Adding option to set user to latest events module instead of getting session data. This is useful in newsletter plugins as it allows to send private events to users with a cronjob.
