### PR TITLE
LanterFish fix for categories query

### DIFF
--- a/component/site/libraries/dbmodel.php
+++ b/component/site/libraries/dbmodel.php
@@ -139,7 +139,6 @@ class JEventsDBModel
 			$db->setQuery($query);
 
 			$catlist = $db->loadColumn();
-			$catlist = $db->loadColumn();
 
 			$instances[$index] = implode(',', array_merge(array(-1), $catlist));
 

--- a/component/site/libraries/dbmodel.php
+++ b/component/site/libraries/dbmodel.php
@@ -110,7 +110,7 @@ class JEventsDBModel
 				$isedit = true;
 			}
 
-			$query = "SELECT c.id"
+			/*$query = "SELECT c.id"
 				. "\n FROM #__categories AS c"
 				. "\n WHERE c.access  " . (version_compare(JVERSION, '1.6.0', '>=') ? ' IN (' . $aid . ')' : ' <=  ' . $aid)
 				. $q_published
@@ -120,9 +120,9 @@ class JEventsDBModel
 				. "\n " . $where
 				. "\n ORDER BY c.lft asc"  ;
 
-			$db->setQuery($query);
+			$db->setQuery($query);*/
 			/* This was a fix for Lanternfish/Joomfish - but it really buggers stuff up!! - you don't just get the id back !!!! */
-			/*
+
 			$whereQuery = "c.access  " . (version_compare(JVERSION, '1.6.0', '>=') ? ' IN (' . $aid . ')' : ' <=  ' . $aid)
 					. $q_published
 					// language filter only applies when not editing
@@ -135,7 +135,10 @@ class JEventsDBModel
 			->from('#__categories AS c')
 			->where($whereQuery)
 			->order('c.lft asc');
-			 */
+
+			$db->setQuery($query);
+
+			$catlist = $db->loadColumn();
 			$catlist = $db->loadColumn();
 
 			$instances[$index] = implode(',', array_merge(array(-1), $catlist));


### PR DESCRIPTION
This just changes query from string to Joomla query builder so that LanterFish can do its job. Previous attempt was missing $db->setQuery($query); and was since executing some other sql. Sorry for that :)