### PR TITLE
Fixed URL recreation (fixes #267)

### DIFF
--- a/component/site/libraries/iCalImport.php
+++ b/component/site/libraries/iCalImport.php
@@ -124,8 +124,8 @@ class iCalImport
 							return false;
 						} else {
 							$fsock_path = ((array_key_exists('path', $parsed_url)) ? $parsed_url['path'] : '')
-							. ((array_key_exists('query', $parsed_url)) ? $parsed_url['query'] : '')
-							. ((array_key_exists('fragment', $parsed_url)) ? $parsed_url['fragment'] : '');
+							. ((array_key_exists('query', $parsed_url)) ? '?' . $parsed_url['query'] : '')
+							. ((array_key_exists('fragment', $parsed_url)) ? '#' . $parsed_url['fragment'] : '');
 							fputs($fh, "GET $fsock_path HTTP/1.0\r\n");
 							fputs($fh, "Host: ".$parsed_url['host']."\r\n\r\n");
 							while(!feof($fh)) {


### PR DESCRIPTION
Hey,

this PR fixes importing calendar files through `fsockopen` containing query and/or hash parts.

Cheers
Matthias