### PR TITLE
Fixes issue where users not authorised to publish events auto-publish…

### DIFF
--- a/component/admin/libraries/saveIcalEvent.php
+++ b/component/admin/libraries/saveIcalEvent.php
@@ -153,9 +153,9 @@ class SaveIcalEvent {
 		}
 		// Always un-publish if no Publisher otherwise publish automatically (for new events)
 		// Should we always notify of new events
-		$notifyAdmin = $cfg->get("com_notifyallevents",0);
+		$notifyAdmin = $cfg->get("com_notifyallevents", 0);
 		if (!$frontendPublish){
-			if($cfg->get('jevunpublishonedit','1'))
+			if($newevent || (int) $cfg->get('jevunpublishonedit', '1') === 1)
 			{
 				$vevent->state = 0;
 			}


### PR DESCRIPTION
Fixes issue where users not authorised to publish events auto-published new events, based on the new setting @carcam added to the permissions tab which allows users to edit an event without it requiring re-publishing.