### PR TITLE
Skip our sanitization completely if the user has allowed raw.

### DIFF
--- a/component/admin/controllers/icalevent.php
+++ b/component/admin/controllers/icalevent.php
@@ -1130,7 +1130,7 @@ class AdminIcaleventController extends JControllerAdmin
 		$jinput = JFactory::getApplication()->input;
 		$array  = $jinput->getArray(array(), null, 'RAW');
 
-		if (version_compare(JVERSION, '3.7.1', '>='))
+		if (version_compare(JVERSION, '3.7.1', '>=') && !$params->get('allowraw', 0))
         {
 
 			$filter = JFilterInput::getInstance(null, null, 1, 1);


### PR DESCRIPTION
We were over filtering basically... If the user specifically allows unfiltered content we should respect their wishes. We were stripping JS/onclicks from custom field values etc.