### PR TITLE
Allow editors to Save/Apply changes.

### DIFF
--- a/component/site/controllers/icalevent.php
+++ b/component/site/controllers/icalevent.php
@@ -148,7 +148,7 @@ class ICalEventController extends AdminIcaleventController   {
 
 	function editcopy(){
 		// Must be at least an event creator to edit or create events
-		$is_event_editor = JEVHelper::isEventCreator();
+		$is_event_editor = JEVHelper::isEventCreator() || JEVHelper::isEventEditor();
 		if (!$is_event_editor){
 			throw new Exception( JText::_('ALERTNOTAUTH'), 403);
 			return false;
@@ -164,7 +164,7 @@ class ICalEventController extends AdminIcaleventController   {
 
 	function save($key = NULL, $urlVar = NULL){
 		// Must be at least an event creator to save events
-		$is_event_editor = JEVHelper::isEventEditor();
+		$is_event_editor = JEVHelper::isEventCreator() || JEVHelper::isEventEditor();
 		if (!$is_event_editor){
 			throw new Exception( JText::_('ALERTNOTAUTH'), 403);
 			return false;

--- a/component/site/controllers/icalevent.php
+++ b/component/site/controllers/icalevent.php
@@ -164,7 +164,7 @@ class ICalEventController extends AdminIcaleventController   {
 
 	function save($key = NULL, $urlVar = NULL){
 		// Must be at least an event creator to save events
-		$is_event_editor = JEVHelper::isEventCreator();
+		$is_event_editor = JEVHelper::isEventEditor();
 		if (!$is_event_editor){
 			throw new Exception( JText::_('ALERTNOTAUTH'), 403);
 			return false;
@@ -174,8 +174,8 @@ class ICalEventController extends AdminIcaleventController   {
 
 	function apply(){
 		// Must be at least an event creator to save events
-		$is_event_editor = JEVHelper::isEventCreator();
-		if (!$is_event_editor){
+		$is_event_editor = JEVHelper::isEventEditor();
+		if (!$is_event_editor) {
 			throw new Exception( JText::_('ALERTNOTAUTH'), 403);
 			return false;
 		}

--- a/component/site/controllers/icalevent.php
+++ b/component/site/controllers/icalevent.php
@@ -174,7 +174,7 @@ class ICalEventController extends AdminIcaleventController   {
 
 	function apply(){
 		// Must be at least an event creator to save events
-		$is_event_editor = JEVHelper::isEventEditor();
+		$is_event_editor = JEVHelper::isEventCreator() || JEVHelper::isEventEditor();
 		if (!$is_event_editor) {
 			throw new Exception( JText::_('ALERTNOTAUTH'), 403);
 			return false;


### PR DESCRIPTION
Event editors cannot save changes in the frontend at present if they are not creators too. 

This change allows them to save, my concern is with the save function, should we check it's not a new event prior to approving saving?