### PR TITLE
Set calendar.php to set today as today always

### DIFF
--- a/component/admin/controllers/cpanel.php
+++ b/component/admin/controllers/cpanel.php
@@ -31,7 +31,7 @@ class AdminCpanelController extends JControllerAdmin
 	function cpanel()
 	{
 		
-		$db = JFactory::getDBO();
+		$db = JFactory::getDbo();
                 
                 // Enable Jevents Installer Plugin
                // $query = "UPDATE #__extensions SET enabled=1 WHERE folder='installer' and type='plugin' and element='jeventsinstaller'";
@@ -160,7 +160,7 @@ class AdminCpanelController extends JControllerAdmin
 	function fixExceptions()
 	{
 
-		$db = JFactory::getDBO();
+		$db = JFactory::getDbo();
 		$db->setQuery("SELECT * FROM #__jevents_exception where exception_type=1 AND (oldstartrepeat='0000-00-00 00:00:00' OR  oldstartrepeat is null) ORDER BY eventid ASC, startrepeat asc");
 		//$db->setQuery("SELECT * FROM #__jevents_exception where exception_type=1 ORDER BY eventid ASC, startrepeat asc");
 		$rows = $db->loadObjectList("rp_id");
@@ -435,7 +435,7 @@ class AdminCpanelController extends JControllerAdmin
 				{
 					$oldPackage = true;
 
-					$db = JFactory::getDBO();
+					$db = JFactory::getDbo();
 					// Add one category by default if none exist already
 					$sql = "SELECT element from #__extensions WHERE type = 'file'";
 					$db->setQuery($sql);
@@ -778,7 +778,7 @@ class AdminCpanelController extends JControllerAdmin
 	}
 
 	private function fixOrphanEvents() {
-		$db = JFactory::getDBO();
+		$db = JFactory::getDbo();
 		$hasOrphans = false;
 
 		$sql = "SELECT ev.ev_id from #__jevents_vevent as ev
@@ -878,7 +878,7 @@ WHERE ics.ics_id is null
 
 	private function createOrphanCalendar() {
 		$catid=$this->createOrphanCategory();
-		$db = JFactory::getDBO();
+		$db = JFactory::getDbo();
 		// Add orphan native calendar by default if none exist already
 		$sql = "SELECT ics_id from #__jevents_icsfile WHERE icaltype=2 and label='Orphans'";
 		$db->setQuery($sql);
@@ -899,7 +899,7 @@ WHERE ics.ics_id is null
 
 
 	private function createOrphanCategory() {
-		$db = JFactory::getDBO();
+		$db = JFactory::getDbo();
 
 		$sql = "SELECT id from #__categories where extension='com_jevents' AND title='Orphans'";
 		$db->setQuery($sql);

--- a/component/admin/controllers/defaults.php
+++ b/component/admin/controllers/defaults.php
@@ -34,7 +34,7 @@ class AdminDefaultsController extends JControllerForm {
 		$this->registerDefaultTask("overview");
 
 		// Make sure DB is up to date
-		$db = JFactory::getDBO();
+		$db = JFactory::getDbo();
 		$db->setQuery("SELECT * FROM #__jev_defaults");
 		$defaults =$db->loadObjectList("name");
 		if (!isset($defaults['icalevent.detail_body'])){
@@ -169,7 +169,7 @@ class AdminDefaultsController extends JControllerForm {
 	function unpublish(){
 		$jinput = JFactory::getApplication()->input;
 
-		$db= JFactory::getDBO();
+		$db= JFactory::getDbo();
 		$cid = $jinput->get("cid", array(), "array");
 		if (count($cid)!=1) {
 			$this->setRedirect(JRoute::_("index.php?option=".JEV_COM_COMPONENT."&task=defaults.overview",false) );
@@ -186,7 +186,7 @@ class AdminDefaultsController extends JControllerForm {
 	}
 
 	function publish(){
-		$db= JFactory::getDBO();
+		$db= JFactory::getDbo();
 		$jinput = JFactory::getApplication()->input;
 
 		$cid = $jinput->get("cid",array(), "array");
@@ -268,7 +268,7 @@ class AdminDefaultsController extends JControllerForm {
 	}
 
 	private function populateLanguages() {
-		$db = JFactory::getDBO();
+		$db = JFactory::getDbo();
 			
 		// get the list of languages first 
 		$query	= $db->getQuery(true);
@@ -412,7 +412,7 @@ class AdminDefaultsController extends JControllerForm {
 	}
 
 	private function populateCategories() {
-		$db = JFactory::getDBO();
+		$db = JFactory::getDbo();
 
 		// get the list of categories first
 		$query	= $db->getQuery(true);

--- a/component/admin/controllers/icalevent.php
+++ b/component/admin/controllers/icalevent.php
@@ -1453,8 +1453,6 @@ class AdminIcaleventController extends JControllerAdmin
 
 	function emptytrash()
 	{
-	    $app    = JFactory::getApplication();
-	    $jinput = $app->input();
 		// clean out the cache
 		$cache = JFactory::getCache('com_jevents');
 		$cache->clean(JEV_COM_COMPONENT);
@@ -1466,8 +1464,11 @@ class AdminIcaleventController extends JControllerAdmin
 		 return false;
 		  }
 		 */
-		$cid = $jinput->get('cid', array(0), "array");
 
+		$app    = JFactory::getApplication();
+		$jinput = $app->input;
+
+		$cid = $jinput->get('cid', array(0), "array");
 		$cid = ArrayHelper::toInteger($cid);
 
 		// front end passes the id as evid
@@ -1484,7 +1485,7 @@ class AdminIcaleventController extends JControllerAdmin
 			$event = $this->queryModel->getEventById(intval($id), 1, "icaldb");
 			if (is_null($event) || !JEVHelper::canDeleteEvent($event))
 			{
-				$app->enqueueMessage('534 -' . JText::_('JEV_NO_DELETE_ROW'), 'warning');
+				JFactory::getApplication()->enqueueMessage('534 -' . JText::_('JEV_NO_DELETE_ROW'), 'warning');
 
 				unset($cid[$key]);
 			}
@@ -1547,25 +1548,25 @@ class AdminIcaleventController extends JControllerAdmin
 			}
 			else
 			{
-				$Itemid = $app->getInt("Itemid");
+				$Itemid = $jinput->getInt("Itemid");
 				list($year, $month, $day) = JEVHelper::getYMD();
-				$rettask = $app->getString("rettask", "day.listevents");
+				$rettask = $jinput->getString("rettask", "day.listevents");
 				$this->setRedirect(JRoute::_('index.php?option=' . JEV_COM_COMPONENT . "&task=$rettask&year=$year&month=$month&day=$day&Itemid=$Itemid", false), JTEXT::_("ICAL_EVENT_DELETED"));
 				$this->redirect();
 			}
 		}
 		else
 		{
-			if (JFactory::getApplication()->isAdmin())
+			if ($app->isAdmin())
 			{
 				$this->setRedirect("index.php?option=" . JEV_COM_COMPONENT . "&task=icalevent.list");
 				$this->redirect();
 			}
 			else
 			{
-				$Itemid = $app->getInt("Itemid");
+				$Itemid = $jinput->getInt("Itemid");
 				list($year, $month, $day) = JEVHelper::getYMD();
-				$rettask = $app->getString("rettask", "day.listevents");
+				$rettask = $jinput-getString("rettask", "day.listevents");
 				$this->setRedirect(JRoute::_('index.php?option=' . JEV_COM_COMPONENT . "&task=$rettask&year=$year&month=$month&day=$day&Itemid=$Itemid", false));
 				$this->redirect();
 			}

--- a/component/admin/controllers/icalevent.php
+++ b/component/admin/controllers/icalevent.php
@@ -64,7 +64,7 @@ class AdminIcaleventController extends JControllerAdmin
 
 		$jinput = JFactory::getApplication()->input;
 
-		$db = JFactory::getDBO();
+		$db = JFactory::getDbo();
 
 		$icsFile = intval(JFactory::getApplication()->getUserStateFromRequest("icsFile", "icsFile", 0));
 
@@ -466,7 +466,7 @@ class AdminIcaleventController extends JControllerAdmin
 
 		$repeatId = 0;
 
-		$db = JFactory::getDBO();
+		$db = JFactory::getDbo();
 
 		// iCal agid uses GUID or UUID as identifier
 		if ($id > 0)
@@ -1238,7 +1238,7 @@ class AdminIcaleventController extends JControllerAdmin
 			}
 			if ($clearout)
 			{
-				$db = JFactory::getDBO();
+				$db = JFactory::getDbo();
 				$query = "DELETE FROM #__jevents_exception WHERE eventid = " . intval($array["evid"]);
 				$db->setQuery($query);
 				$db->execute();
@@ -1315,7 +1315,7 @@ class AdminIcaleventController extends JControllerAdmin
 			$cid = array($jinput->getInt("evid", 0));
 		}
 
-		$db = JFactory::getDBO();
+		$db = JFactory::getDbo();
 
 		foreach ($cid as $key => $id)
 		{
@@ -1453,6 +1453,8 @@ class AdminIcaleventController extends JControllerAdmin
 
 	function emptytrash()
 	{
+	    $app    = JFactory::getApplication();
+	    $jinput = $app->input();
 		// clean out the cache
 		$cache = JFactory::getCache('com_jevents');
 		$cache->clean(JEV_COM_COMPONENT);
@@ -1464,16 +1466,17 @@ class AdminIcaleventController extends JControllerAdmin
 		 return false;
 		  }
 		 */
-		$cid = JRequest::getVar('cid', array(0));
+		$cid = $jinput->get('cid', array(0), "array");
+
 		$cid = ArrayHelper::toInteger($cid);
 
 		// front end passes the id as evid
 		if (count($cid) == 1 && $cid[0] == 0)
 		{
-			$cid = array(JRequest::getInt("evid", 0));
+			$cid = array($jinput->getInt("evid", 0));
 		}
 
-		$db = JFactory::getDBO();
+		$db = JFactory::getDbo();
 
 		foreach ($cid as $key => $id)
 		{
@@ -1481,7 +1484,7 @@ class AdminIcaleventController extends JControllerAdmin
 			$event = $this->queryModel->getEventById(intval($id), 1, "icaldb");
 			if (is_null($event) || !JEVHelper::canDeleteEvent($event))
 			{
-				JFactory::getApplication()->enqueueMessage('534 -' . JText::_('JEV_NO_DELETE_ROW'), 'warning');
+				$app->enqueueMessage('534 -' . JText::_('JEV_NO_DELETE_ROW'), 'warning');
 
 				unset($cid[$key]);
 			}
@@ -1544,9 +1547,9 @@ class AdminIcaleventController extends JControllerAdmin
 			}
 			else
 			{
-				$Itemid = JRequest::getInt("Itemid");
+				$Itemid = $app->getInt("Itemid");
 				list($year, $month, $day) = JEVHelper::getYMD();
-				$rettask = JRequest::getString("rettask", "day.listevents");
+				$rettask = $app->getString("rettask", "day.listevents");
 				$this->setRedirect(JRoute::_('index.php?option=' . JEV_COM_COMPONENT . "&task=$rettask&year=$year&month=$month&day=$day&Itemid=$Itemid", false), JTEXT::_("ICAL_EVENT_DELETED"));
 				$this->redirect();
 			}
@@ -1560,9 +1563,9 @@ class AdminIcaleventController extends JControllerAdmin
 			}
 			else
 			{
-				$Itemid = JRequest::getInt("Itemid");
+				$Itemid = $app->getInt("Itemid");
 				list($year, $month, $day) = JEVHelper::getYMD();
-				$rettask = JRequest::getString("rettask", "day.listevents");
+				$rettask = $app->getString("rettask", "day.listevents");
 				$this->setRedirect(JRoute::_('index.php?option=' . JEV_COM_COMPONENT . "&task=$rettask&year=$year&month=$month&day=$day&Itemid=$Itemid", false));
 				$this->redirect();
 			}
@@ -1575,7 +1578,7 @@ class AdminIcaleventController extends JControllerAdmin
 		// TODO switch this after migration
 		$component_name = "com_jevents";
 
-		$db = JFactory::getDBO();
+		$db = JFactory::getDbo();
 		$query = "SELECT COUNT(*) AS count FROM #__categories WHERE extension = '$component_name' AND `published` = 1;";  // RSH 9/28/10 added check for valid published, J!1.6 sets deleted categoris to published = -2
 		$db->setQuery($query);
 		$count = intval($db->loadResult());
@@ -1591,7 +1594,7 @@ class AdminIcaleventController extends JControllerAdmin
 
 	function select()
 	{
-		JRequest::checkToken('default') or jexit('Invalid Token');
+		JSession::checkToken('default') or jexit('Invalid Token');
 
 		// get the view
 		if (JFactory::getApplication()->isAdmin()){
@@ -1606,7 +1609,7 @@ class AdminIcaleventController extends JControllerAdmin
 		$showUnpublishedICS = false;
 		$showUnpublishedCategories = false;
 
-		$db = JFactory::getDBO();
+		$db = JFactory::getDbo();
 
 		$icsFile = intval(JFactory::getApplication()->getUserStateFromRequest("icsFile", "icsFile", 0));
 
@@ -1884,7 +1887,7 @@ class AdminIcaleventController extends JControllerAdmin
 
 	private function targetMenu($itemid = 0, $name)
 	{
-		$db = JFactory::getDBO();
+		$db = JFactory::getDbo();
 
 		// assemble menu items to the array
 		$options = array();

--- a/component/admin/controllers/icalrepeat.php
+++ b/component/admin/controllers/icalrepeat.php
@@ -50,7 +50,7 @@ class AdminIcalrepeatController extends JControllerLegacy
 	{
 		$jinput = JFactory::getApplication()->input;
 
-		$db = JFactory::getDBO();
+		$db = JFactory::getDbo();
 		$publishedOnly = false;
 		$cid = $jinput->get('cid', array(0),"array");
 		$cid = ArrayHelper::toInteger($cid);
@@ -147,8 +147,11 @@ class AdminIcalrepeatController extends JControllerLegacy
 			$this->view->setModel($model, true);
 		}
 
-		$db = JFactory::getDBO();
-		$cid = JRequest::getVar('cid', array(0));
+		$app    = JFactory::getApplication();
+		$jinput = $app->input;
+
+		$db = JFactory::getDbo();
+		$cid = $jinput->get('cid', array(0), "array");
 		$cid = ArrayHelper::toInteger($cid);
 		if (is_array($cid) && count($cid) > 0)
 			$id = $cid[0];
@@ -164,10 +167,10 @@ class AdminIcalrepeatController extends JControllerLegacy
 		// front end passes the id as evid
 		if ($id == 0)
 		{
-			$id = JRequest::getInt("evid", 0);
+			$id = $jinput->getInt("evid", 0);
 		}
 
-		$db = JFactory::getDBO();
+		$db = JFactory::getDbo();
 		$query = "SELECT rpt.eventid"
 				. "\n FROM (#__jevents_vevent as ev, #__jevents_icsfile as icsf)"
 				. "\n LEFT JOIN #__jevents_repetition as rpt ON rpt.eventid = ev.ev_id"
@@ -249,8 +252,6 @@ class AdminIcalrepeatController extends JControllerLegacy
 		$msg = "";
 		$rpt = $this->doSave($msg);
 
-		$Itemid = JRequest::getInt("Itemid");
-		$msg = JText::_("Event_Saved", true);
 		if (JFactory::getApplication()->isAdmin())
 		{
 			$this->setRedirect('index.php?option=' . JEV_COM_COMPONENT . '&task=icalrepeat.list&cid[]=' . $rpt->eventid, "".JText::_("JEV_ICAL_RPT_DETAILS_SAVED")."");
@@ -307,7 +308,6 @@ class AdminIcalrepeatController extends JControllerLegacy
 		$msg = "";
 		$rpt = $this->doSave($msg);
 
-		$Itemid = JRequest::getInt("Itemid");
 		$msg = JText::_("Event_Saved", true);
 		if (JFactory::getApplication()->isAdmin())
 		{
@@ -338,14 +338,17 @@ class AdminIcalrepeatController extends JControllerLegacy
 
 	function select()
 	{
-		JRequest::checkToken('default') or jexit('Invalid Token');
+		JSession::checkToken('default') or jexit('Invalid Token');
 
-		$db = JFactory::getDBO();
+		$app    = JFactory::getApplication();
+		$jinput = $app->input;
+
+		$db = JFactory::getDbo();
 		$publishedOnly = true;
-		$id = JRequest::getInt('evid', 0);
+		$id = $jinput->getInt('evid', 0);
 
-		$limit = intval(JFactory::getApplication()->getUserStateFromRequest("viewlistlimit", 'limit', 10));
-		$limitstart = intval(JFactory::getApplication()->getUserStateFromRequest("view{" . JEV_COM_COMPONENT . "}limitstart", 'limitstart', 0));
+		$limit = (int) JFactory::getApplication()->getUserStateFromRequest("viewlistlimit", 'limit', 10);
+		$limitstart = (int) JFactory::getApplication()->getUserStateFromRequest("view{" . JEV_COM_COMPONENT . "}limitstart", 'limitstart', 0);
 
 		$user = JFactory::getUser();
 		$where[] = "\n ev.access IN ('" . JEVHelper::getAid($user) . "')";
@@ -399,7 +402,7 @@ class AdminIcalrepeatController extends JControllerLegacy
 			$icalrows[$i] = new jIcalEventRepeat($icalrows[$i]);
 		}
 
-		$menulist = $this->targetMenu(JRequest::getInt("Itemid"), "Itemid");
+		$menulist = $this->targetMenu($jinput->getInt("Itemid"), "Itemid");
 
 		jimport('joomla.html.pagination');
 		$pageNav = new JPagination($total, $limitstart, $limit);
@@ -693,7 +696,7 @@ class AdminIcalrepeatController extends JControllerLegacy
 
 		// Change the underlying event repeat rule details  !!
 		$query = "SELECT * FROM #__jevents_rrule WHERE rr_id=" . $event->_rr_id;
-		$db = JFactory::getDBO();
+		$db = JFactory::getDbo();
 		$db->setQuery($query);
 		$this->rrule = null;
 		$this->rrule = $db->loadObject();
@@ -802,16 +805,18 @@ class AdminIcalrepeatController extends JControllerLegacy
 			return false;
 		}
 
-		$cid = JRequest::getVar('cid', array(0));
+		$app    = JFactory::getApplication();
+		$jinput = $app->input;
+		$cid    = $jinput->get('cid', array(0), "array");
+
 		if (!is_array($cid))
 			$cid = array(intval($cid));
 			$cid = ArrayHelper::toInteger($cid);
 
-		$db = JFactory::getDBO();
+		$db = JFactory::getDbo();
 		foreach ($cid as $id)
 		{
 
-			$evid = JRequest::getInt("evid", 0);
 			if ($id == 0)
 				continue;
 
@@ -868,14 +873,14 @@ class AdminIcalrepeatController extends JControllerLegacy
 			$db->execute();
 		}
 
-		if (JFactory::getApplication()->isAdmin())
+		if ($app->isAdmin())
 		{
 			$this->setRedirect("index.php?option=" . JEV_COM_COMPONENT . "&task=icalrepeat.list&cid[]=" . $data->eventid, JText::_("JEV_ICAL_REPEAT_DELETED"));
 			$this->redirect();
 		}
 		else
 		{
-			$Itemid = JRequest::getInt("Itemid");
+			$Itemid = $jinput->getInt("Itemid");
 			list($year, $month, $day) = JEVHelper::getYMD();
 			$this->setRedirect(JRoute::_('index.php?option=' . JEV_COM_COMPONENT . "&task=day.listevents&year=$year&month=$month&day=$day&Itemid=$Itemid", false), JText::_("JEV_ICAL_REPEAT_DELETED"));
 			$this->redirect();
@@ -915,12 +920,16 @@ class AdminIcalrepeatController extends JControllerLegacy
 
 	function _deleteFuture()
 	{
-		$cid = JRequest::getVar('cid', array(0));
+
+	    $app    = JFactory::getApplication();
+	    $jinput = $app->input;
+
+		$cid = $jinput->getVar('cid', array(0));
 		if (!is_array($cid))
 			$cid = array(intval($cid));
 		$cid = ArrayHelper::toInteger($cid);
 
-		$db = JFactory::getDBO();
+		$db = JFactory::getDbo();
 		foreach ($cid as $id)
 		{
 
@@ -1035,7 +1044,7 @@ class AdminIcalrepeatController extends JControllerLegacy
 
 	private function targetMenu($itemid = 0, $name)
 	{
-		$db = JFactory::getDBO();
+		$db = JFactory::getDbo();
 
 		// assemble menu items to the array
 		$options = array();

--- a/component/admin/controllers/icals.php
+++ b/component/admin/controllers/icals.php
@@ -169,7 +169,7 @@ class AdminIcalsController extends JControllerForm {
 
 		$item =new stdClass();
 		if ($editItem!=null){
-			$db	= JFactory::getDBO();
+			$db	= JFactory::getDbo();
 			$query = "SELECT * FROM #__jevents_icsfile as ics where ics.ics_id=$editItem";
 
 			$db->setQuery( $query );
@@ -237,7 +237,7 @@ class AdminIcalsController extends JControllerForm {
 
 		// Check for request forgeries
 		if (JRequest::getCmd("task") != "icals.reload" && JRequest::getCmd("task") != "icals.reloadall"){
-			JRequest::checkToken() or jexit( 'Invalid Token' );
+			JSession::checkToken() or jexit( 'Invalid Token' );
 		}
 
 		$user = JFactory::getUser();
@@ -257,7 +257,7 @@ class AdminIcalsController extends JControllerForm {
 		$icsid = intval(JRequest::getVar('icsid',0));
 		if ($icsid>0){
 			$query = "SELECT icsf.* FROM #__jevents_icsfile as icsf WHERE ics_id=$icsid";
-			$db	= JFactory::getDBO();
+			$db	= JFactory::getDbo();
 			$db->setQuery($query);
 			$currentICS = $db->loadObjectList();
 			if (count($currentICS)>0){
@@ -282,7 +282,7 @@ class AdminIcalsController extends JControllerForm {
 			$cid=0;
 		}
 
-		$db	= JFactory::getDBO();
+		$db	= JFactory::getDbo();
 
 		// include ical files
 		
@@ -412,7 +412,7 @@ class AdminIcalsController extends JControllerForm {
 		$authorised = false;
 
 		// Check for request forgeries
-		JRequest::checkToken() or jexit( 'Invalid Token' );
+		JSession::checkToken() or jexit( 'Invalid Token' );
 
 		if (JFactory::getApplication()->isAdmin()){
 			$redirect_task="icals.list";
@@ -436,7 +436,7 @@ class AdminIcalsController extends JControllerForm {
 			$cid=0;
 		}
 
-		$db	= JFactory::getDBO();
+		$db	= JFactory::getDbo();
 
 		// include ical files
 		
@@ -518,7 +518,7 @@ class AdminIcalsController extends JControllerForm {
 			return;
 		}
 
-		$db	= JFactory::getDBO();
+		$db	= JFactory::getDbo();
 		foreach ($cid as $id) {
 			$sql = "UPDATE #__jevents_icsfile SET state=$newstate where ics_id='".$id."'";
 			$db->setQuery($sql);
@@ -548,7 +548,7 @@ class AdminIcalsController extends JControllerForm {
 			return;
 		}
 
-		$db	= JFactory::getDBO();
+		$db	= JFactory::getDbo();
 		foreach ($cid as $id) {
 			$sql = "UPDATE #__jevents_icsfile SET autorefresh=$newstate where ics_id='".$id."'";
 			$db->setQuery($sql);
@@ -578,7 +578,7 @@ class AdminIcalsController extends JControllerForm {
 			return;
 		}
 
-		$db	= JFactory::getDBO();
+		$db	= JFactory::getDbo();
 		// set all to not default first
 		$sql = "UPDATE #__jevents_icsfile SET isdefault=0";
 		$db->setQuery($sql);
@@ -598,7 +598,7 @@ class AdminIcalsController extends JControllerForm {
 	function newical() {
 
 		// Check for request forgeries
-		JRequest::checkToken() or jexit( 'Invalid Token' );
+		JSession::checkToken() or jexit( 'Invalid Token' );
 
 		// include ical files
 		$catid = intval(JRequest::getVar('catid',0));
@@ -644,12 +644,12 @@ class AdminIcalsController extends JControllerForm {
 	function delete(){
 
 		// Check for request forgeries
-		JRequest::checkToken() or jexit( 'Invalid Token' );
+		JSession::checkToken() or jexit( 'Invalid Token' );
 
 		$cid	= JRequest::getVar(	'cid',	array(0) );
 		$cid = ArrayHelper::toInteger($cid);
 
-		$db	= JFactory::getDBO();
+		$db	= JFactory::getDbo();
 
 		// check this won't create orphan events
 		$query = "SELECT ev_id FROM #__jevents_vevent WHERE icsid in (".implode(",",$cid).")";
@@ -671,7 +671,7 @@ class AdminIcalsController extends JControllerForm {
 	}
 
 	function _deleteICal($cid){
-		$db	= JFactory::getDBO();
+		$db	= JFactory::getDbo();
 		$icsids = implode(",",$cid);
 
 		$query = "SELECT ev_id FROM #__jevents_vevent WHERE icsid IN ($icsids)";
@@ -716,7 +716,7 @@ class AdminIcalsController extends JControllerForm {
 		// TODO switch this after migration
 		$component_name = "com_jevents";
 
-		$db	= JFactory::getDBO();
+		$db	= JFactory::getDbo();
 		$query = "SELECT COUNT(*) AS count FROM #__categories WHERE extension = '$component_name' AND `published` = 1;";  // RSH 9/28/10 added check for valid published, J!1.6 sets deleted categoris to published = -2
 		$db->setQuery($query);
 		$count = intval($db->loadResult());

--- a/component/admin/controllers/params.php
+++ b/component/admin/controllers/params.php
@@ -111,7 +111,7 @@ class AdminParamsController extends JControllerAdmin
 	function save($key = NULL, $urlVar = NULL)
 	{
 		// Check for request forgeries
-		JRequest::checkToken() or jexit('Invalid Token');
+		JSession::checkToken() or jexit('Invalid Token');
 		//echo $this->getTask();
 		//exit;
 		$component = JEV_COM_COMPONENT;

--- a/component/admin/controllers/user.php
+++ b/component/admin/controllers/user.php
@@ -86,7 +86,7 @@ class AdminUserController extends JControllerLegacy   {
 
 	function saveUser( ) {
 		// Check for request forgeries
-		JRequest::checkToken() or jexit( 'Invalid Token' );
+		JSession::checkToken() or jexit( 'Invalid Token' );
 
 		if (!JEVHelper::isAdminUser()) {
 			$msg = "Not Authorised";
@@ -116,7 +116,7 @@ class AdminUserController extends JControllerLegacy   {
 
 	function removeUser() {
 		// Check for request forgeries
-		JRequest::checkToken() or jexit( 'Invalid Token' );
+		JSession::checkToken() or jexit( 'Invalid Token' );
 		
 		if (!JEVHelper::isAdminUser()) {
 			$msg = "Not Authorised";
@@ -239,7 +239,7 @@ class AdminUserController extends JControllerLegacy   {
 	
 	private function changeState($field, $newstate, $successMessage){
 		// Check for request forgeries
-		JRequest::checkToken() or jexit( 'Invalid Token' );
+		JSession::checkToken() or jexit( 'Invalid Token' );
 
 		if (!JEVHelper::isAdminUser()) {
 			$msg = "Not Authorised";

--- a/component/admin/fields/jeveventcreator.php
+++ b/component/admin/fields/jeveventcreator.php
@@ -39,7 +39,7 @@ class JFormFieldJeveventcreator extends JFormField
 		//$access = JAccess::check($user->id, "core.deleteall", "com_jevents");
 		$access = $user->authorise('core.admin', 'com_jevents') || $user->authorise('core.deleteall', 'com_jevents');
 
-		$db = JFactory::getDBO();
+		$db = JFactory::getDbo();
 		if (($jevuser && $jevuser->candeleteall) || $access)
 		{
 			$params = JComponentHelper::getParams(JEV_COM_COMPONENT);

--- a/component/admin/fields/jevhtml.php
+++ b/component/admin/fields/jevhtml.php
@@ -13,10 +13,12 @@
 
 defined('JPATH_BASE') or die;
 
-if (file_exists(JPATH_SITE."/libraries/joomla/form/fields/editor.php")){
+if (version_compare(JVERSION, "3.8.0", 'ge')){
+	\JFormHelper::loadFieldClass('editor');
+}
+else if (file_exists(JPATH_SITE."/libraries/joomla/form/fields/editor.php")){
 	include_once(JPATH_SITE."/libraries/joomla/form/fields/editor.php");
 }
-	
 jimport('joomla.html.editor');
 
 class JFormFieldJevhtml extends JFormFieldEditor

--- a/component/admin/fields/jevmenu.php
+++ b/component/admin/fields/jevmenu.php
@@ -41,15 +41,15 @@ class JFormFieldJEVmenu extends JFormFieldList
 
 	public function getOptions()
 	{
-		$jinput = JFactory::getApplication()->input;
+		$app    = JFactory::getApplication();
+		$jinput = $app->input;
 
 		// Trap to stop the config from being editing from the categories page
 		// Updated to redirect to the correct edit page, Joomla 3.x Config actually loads this page when configuration components. 
                 // Only do the redirect in the backend since in the frontend module editing uses com_config (go figure!!!)
-		if ($jinput->getString("option") == "com_config" && JFactory::getApplication()->isAdmin()){
+		if ($jinput->getString("option") == "com_config" && $app->isAdmin()){
 			$redirect_url  =  "index.php?option=com_jevents&task=params.edit"; // get rid of any ampersands
-			$app  =  JFactory::getApplication();
-			$app->redirect($redirect_url); //redirect 
+			$app->redirect($redirect_url); //redirect
 			exit();
 		}
 
@@ -58,12 +58,10 @@ class JFormFieldJEVmenu extends JFormFieldList
 		$lang->load("com_jevents", JPATH_ADMINISTRATOR);
 
 		$node = $this->element;
-		$value = $this->value;
-		$name = $this->name;
-		$control_name = $this->type;
+
 		$strict  = $this->getAttribute("strict", 0);
 		
-		$db = JFactory::getDBO();
+		$db = JFactory::getDbo();
 
 		// assemble menu items to the array
 		$options 	= array();
@@ -77,7 +75,7 @@ class JFormFieldJEVmenu extends JFormFieldList
 		$db->setQuery( $query );
 		$menuTypes = $db->loadObjectList();
 
-		$menu = JFactory::getApplication()->getMenu('site');
+		$menu = $app->getMenu('site');
 		$menuItems = $menu->getMenu();
 		$extension = "com_jevents";
 		if ($node){
@@ -134,10 +132,10 @@ class JFormFieldJEVmenu extends JFormFieldList
 					$item = &$groupedList[$type->menutype][$i];
 					
 					//If menutype is changed but item is not saved yet, use the new type in the list
-					if ( JRequest::getString('option', '', 'get') == 'com_menus' ) {
-						$currentItemArray = JRequest::getVar('cid', array(0), '', 'array');
+					if ( $jinput->getString('option', '', 'get') == 'com_menus' ) {
+						$currentItemArray = $jinput->get('cid', array(0), "array");
 						$currentItemId = (int) $currentItemArray[0];
-						$currentItemType = JRequest::getString('type', $item->type, 'get');
+						$currentItemType = $jinput->getString('type', $item->type, 'get');
 						if ( $currentItemId == $item->id && $currentItemType != $item->type) {
 							$item->type = $currentItemType;
 						}

--- a/component/admin/fields/jevselectevent.php
+++ b/component/admin/fields/jevselectevent.php
@@ -61,7 +61,7 @@ class JFormFieldJEVselectEvent extends JFormField
 		// get the repeat id
 		$rpidfield = $this->form->getField("rp_id", "request");
 		$rp_id = $rpidfield->value;
-		$db	= JFactory::getDBO();
+		$db	= JFactory::getDbo();
 		$query = $db->getQuery(true);
 		$query
 				->select($db->quoteName('det.summary', 'title'))

--- a/component/admin/fields/jevuser.php
+++ b/component/admin/fields/jevuser.php
@@ -46,7 +46,7 @@ class JFormFieldJEVuser extends JFormFieldList
 	{
 		$params = JComponentHelper::getParams("com_jevents");
 
-		$db = JFactory::getDBO();
+		$db = JFactory::getDbo();
 
                 // if editing category then find the rules for a specific category
                 if ($this->name == "jform[params][admin]" 

--- a/component/admin/jevents.php
+++ b/component/admin/jevents.php
@@ -83,7 +83,7 @@ $lang->load(JEV_COM_COMPONENT, JPATH_SITE);
 
 if (!version_compare(JVERSION,'1.6.0',">=")){
 	// Load Site specific language overrides - can't use getTemplate since we are in the admin interface
-	$db = JFactory::getDBO();
+	$db = JFactory::getDbo();
 	$query = 'SELECT template'
 	. ' FROM #__templates_menu'
 	. ' WHERE client_id = 0 AND menuid=0'
@@ -179,7 +179,7 @@ $jinput->set("jevcmd", $cmd);
 JPluginHelper::importPlugin("jevents");
 
 // Make this a config option - should not normally be needed
-//$db = JFactory::getDBO();
+//$db = JFactory::getDbo();
 //$db->setQuery( "SET SQL_BIG_SELECTS=1");
 //$db->execute();
 

--- a/component/admin/libraries/adminqueries.php
+++ b/component/admin/libraries/adminqueries.php
@@ -24,7 +24,7 @@ class JEventsAdminDBModel extends JEventsDBModel {
  * @return stdClass details of vevent selected
  */
 	function getVEventById( $agid) {
-		$db	= JFactory::getDBO();
+		$db	= JFactory::getDbo();
 		$user = JFactory::getUser();
 		// force state value to event state!
 		$accessibleCategories = $this->accessibleCategoryList();
@@ -116,7 +116,7 @@ class JEventsAdminDBModel extends JEventsDBModel {
 	}
 
 	function getVEventRepeatById( $rp_id) {
-		$db	= JFactory::getDBO();
+		$db	= JFactory::getDbo();
 		$user = JFactory::getUser();
 		$accessibleCategories = $this->accessibleCategoryList();
 		$query = "SELECT ev.*, rpt.*, rr.*, det.*"
@@ -169,7 +169,7 @@ class JEventsAdminDBModel extends JEventsDBModel {
 	// TODO add more access control e.g. canpublish caneditown etc.
 
 	function getNativeIcalendars() {
-		$db	= JFactory::getDBO();
+		$db	= JFactory::getDbo();
 		$user = JFactory::getUser();
 		$query = "SELECT *"
 		. "\n FROM #__jevents_icsfile as ical"
@@ -188,7 +188,7 @@ class JEventsAdminDBModel extends JEventsDBModel {
 	}
 
 	function getIcalByIcsid($icsid) {
-		$db	= JFactory::getDBO();
+		$db	= JFactory::getDbo();
 		$user = JFactory::getUser();
 		$query = "SELECT *"
 		. "\n FROM #__jevents_icsfile as ical"
@@ -213,7 +213,7 @@ class JEventsAdminDBModel extends JEventsDBModel {
 	 */
 	function getModulesByName($module='mod_events_latest') {
 
-		$db	= JFactory::getDBO();
+		$db	= JFactory::getDbo();
 		$query = "select *"
 		. "\n from #__modules"
 		. "\n where module='" . $module . "'";

--- a/component/admin/libraries/categoryClass.php
+++ b/component/admin/libraries/categoryClass.php
@@ -112,7 +112,7 @@ class JEventsCategory extends JTableCategory {
 
 	public static function categoriesTree() {
 
-		$db = JFactory::getDBO();
+		$db = JFactory::getDbo();
 		$query = "SELECT *, parent_id as parent FROM #__categories  WHERE extension = '".JEV_COM_COMPONENT."' and published>=0";
 		$query.=" ORDER BY parent, lft";
 		$db->setQuery($query);

--- a/component/admin/libraries/jevlayout.php
+++ b/component/admin/libraries/jevlayout.php
@@ -36,7 +36,7 @@ class JInstallerJevlayout extends JAdapterInstance
 	function install()
 	{
 		// Get a database connector object
-		$db =& $this->parent->getDBO();
+		$db =& $this->parent->getDbo();
 
 		// Get the extension manifest object
 		$this->manifest = $this->parent->getManifest();

--- a/component/admin/models/defaults.php
+++ b/component/admin/models/defaults.php
@@ -19,7 +19,7 @@ class DefaultsModelDefaults extends JModelLegacy
 		// Lets load the content if it doesn't already exist
 		if (empty($this->_data))
 		{
-			$db = JFactory::getDBO();
+			$db = JFactory::getDbo();
 			$query	= $db->getQuery(true);
 			
 			$query->select("def.*");
@@ -93,7 +93,7 @@ class DefaultsModelDefaults extends JModelLegacy
 		if (empty($this->_total))
 		{
 			// Manually add the form data which is not stored in the database in the same way
-			$db = JFactory::getDBO();
+			$db = JFactory::getDbo();
 			$language  = JFactory::getApplication()->getUserStateFromRequest("jevdefaults.filter_language", 'filter_language', "*");
 			
 			$query	= $db->getQuery(true);
@@ -120,7 +120,7 @@ class DefaultsModelDefaults extends JModelLegacy
 	{
 		static  $languages;
 		if (!isset($languages)){
-			$db = JFactory::getDBO();
+			$db = JFactory::getDbo();
 
 			// get the list of languages first 
 			$query	= $db->getQuery(true);

--- a/component/admin/models/icalevent.php
+++ b/component/admin/models/icalevent.php
@@ -177,7 +177,7 @@ class IcaleventsModelicalevent extends JModelAdmin
 	{
 		static  $languages;
 		if (!isset($languages)){
-			$db = JFactory::getDBO();
+			$db = JFactory::getDbo();
 
 			// get the list of languages first
 			$query	= $db->getQuery(true);

--- a/component/admin/tables/default.php
+++ b/component/admin/tables/default.php
@@ -41,7 +41,7 @@ class TableDefault extends JTable
 	 * @since 1.0
 	 */
 	function __construct() {
-		$db = JFactory::getDBO();
+		$db = JFactory::getDbo();
 		parent::__construct('#__jev_defaults', 'id', $db);
 	}
 

--- a/component/admin/tables/jevuser.php
+++ b/component/admin/tables/jevuser.php
@@ -65,12 +65,12 @@ class TableUser extends JTable
 	 * @since 1.0
 	 */
 	function __construct() {
-		$db = JFactory::getDBO();
+		$db = JFactory::getDbo();
 		parent::__construct('#__jev_users', 'id', $db);
 	}
 
 	public static function checkTable(){
-		$db = JFactory::getDBO();
+		$db = JFactory::getDbo();
 	}
 
 	/**
@@ -101,7 +101,7 @@ class TableUser extends JTable
 			$where[] = "tl.id in ($idstring)";
 		}
 
-		$db = JFactory::getDBO();
+		$db = JFactory::getDbo();
 		$search		= JFactory::getApplication()->getUserStateFromRequest( "usersearch{".JEV_COM_COMPONENT."}", 'search', '' );
 		$search		= $db->escape( trim( strtolower( $search ) ) );		
 		if($search != ""){
@@ -168,7 +168,7 @@ class TableUser extends JTable
 		$join = array();
 		$set = $dispatcher->trigger('getAuthorisedUser', array (& $where, & $join));
 
-		$db = JFactory::getDBO();
+		$db = JFactory::getDbo();
 		$sql = "SELECT tl.*, ju.name as jname, ju.username  FROM #__jev_users AS tl ";
 		$sql .= " LEFT JOIN #__users as ju ON tl.user_id=ju.id ";
 		$sql .= count($join)>0?implode(" ",$join):"";
@@ -197,7 +197,7 @@ class TableUser extends JTable
 		$join = array();
 		$set = $dispatcher->trigger('getAuthorisedUser', array (& $where, & $join));
 
-		$db = JFactory::getDBO();
+		$db = JFactory::getDbo();
 		$sql = "SELECT tl.*, ju.name as jname, ju.username  FROM #__jev_users AS tl ";
 		$sql .= " LEFT JOIN #__users as ju ON tl.user_id=ju.id ";
 		$sql .= count($join)>0?implode(" ",$join):"";

--- a/component/admin/tables/translate.php
+++ b/component/admin/tables/translate.php
@@ -39,12 +39,12 @@ class TableTranslate extends JTable
 	 * @since 1.0
 	 */
 	function __construct() {
-		$db = JFactory::getDBO();
+		$db = JFactory::getDbo();
 		parent::__construct('#__jevents_translation', 'translation_id', $db);
 	}
 
 	public static function checkTable(){
-		$db = JFactory::getDBO();
+		$db = JFactory::getDbo();
 	}
 
 	function bind($array, $ignore = '') {

--- a/component/admin/views/abstract/abstract.php
+++ b/component/admin/views/abstract/abstract.php
@@ -220,7 +220,7 @@ class JEventsAbstractView extends JViewLegacy
 	 */
 	function loadEditFromTemplate($template_name = 'icalevent.edit_page', $event, $mask, $search = array(), $replace = array(), $blank = array())
 	{
-		$db = JFactory::getDBO();
+		$db = JFactory::getDbo();
 		// find published template
 		static $templates;
 		static $fieldNameArray;

--- a/component/admin/views/defaults/view.html.php
+++ b/component/admin/views/defaults/view.html.php
@@ -40,7 +40,7 @@ class AdminDefaultsViewDefaults extends JEventsAbstractView
 
 		JHTML::_('behavior.tooltip');
 
-		$db = JFactory::getDBO();
+		$db = JFactory::getDbo();
 		$uri =  JFactory::getURI();
 
 		// Get data from the model
@@ -122,7 +122,7 @@ class AdminDefaultsViewDefaults extends JEventsAbstractView
 
 
 
-		$db = JFactory::getDBO();
+		$db = JFactory::getDbo();
 		$uri =  JFactory::getURI();
 
 		// Get data from the model

--- a/component/admin/views/icalevent/tmpl/csvimport.php
+++ b/component/admin/views/icalevent/tmpl/csvimport.php
@@ -12,7 +12,7 @@ defined('_JEXEC') or die('Restricted access');
 
 JHTML::_('behavior.tooltip');
 
-$db	= JFactory::getDBO();
+$db	= JFactory::getDbo();
 $user = JFactory::getUser();
 ?>
 <form action="index.php" method="post" name="adminForm" enctype="multipart/form-data" id="adminForm">

--- a/component/admin/views/icalevent/tmpl/overview.php
+++ b/component/admin/views/icalevent/tmpl/overview.php
@@ -17,7 +17,7 @@ use Joomla\String\StringHelper;
 
 JHTML::_('behavior.tooltip');
 
-$db = JFactory::getDBO();
+$db = JFactory::getDbo();
 $user = JFactory::getUser();
 
 // get configuration object

--- a/component/admin/views/icalevent/tmpl/select.php
+++ b/component/admin/views/icalevent/tmpl/select.php
@@ -14,7 +14,7 @@ JHTML::_('behavior.tooltip');
 
 use Joomla\String\StringHelper;
 
-$db = JFactory::getDBO();
+$db = JFactory::getDbo();
 $user = JFactory::getUser();
 $jinput = JFactory::getApplication()->input;
 // get configuration object

--- a/component/admin/views/icalevent/view.html.php
+++ b/component/admin/views/icalevent/view.html.php
@@ -294,7 +294,7 @@ class AdminIcaleventViewIcalevent extends JEventsAbstractView
 		//$access = JAccess::check($user->id, "core.deleteall", "com_jevents");
 		$access = $user->authorise('core.admin', 'com_jevents') || $user->authorise('core.deleteall', 'com_jevents');
 
-		$db = JFactory::getDBO();
+		$db = JFactory::getDbo();
 		if (($jevuser && $jevuser->candeleteall) || $access)
 		{
 			$params = JComponentHelper::getParams(JEV_COM_COMPONENT);

--- a/component/admin/views/icalrepeat/tmpl/overview.php
+++ b/component/admin/views/icalrepeat/tmpl/overview.php
@@ -11,7 +11,7 @@
 defined('_JEXEC') or die('Restricted access'); 
 
 global   $task;
-$db	= JFactory::getDBO();
+$db	= JFactory::getDbo();
 $user = JFactory::getUser();
 JHTML::_('behavior.tooltip');
 

--- a/component/admin/views/icalrepeat/tmpl/select.php
+++ b/component/admin/views/icalrepeat/tmpl/select.php
@@ -11,7 +11,7 @@
 defined('_JEXEC') or die('Restricted access');
 
 global $task;
-$db = JFactory::getDBO();
+$db = JFactory::getDbo();
 $user = JFactory::getUser();
 JHTML::_('behavior.tooltip');
 

--- a/component/admin/views/icals/tmpl/edit.php
+++ b/component/admin/views/icals/tmpl/edit.php
@@ -12,7 +12,7 @@ defined('_JEXEC') or die('Restricted access');
 
 
 global $task, $catid;
-$db = JFactory::getDBO();
+$db = JFactory::getDbo();
 $editor =  JFactory::getEditor();
 
 // clean any existing cache files

--- a/component/admin/views/icals/tmpl/edit16.php
+++ b/component/admin/views/icals/tmpl/edit16.php
@@ -12,7 +12,7 @@ defined('_JEXEC') or die('Restricted access');
 
 
 global $task,$catid;
-$db	= JFactory::getDBO();
+$db	= JFactory::getDbo();
 $editor = JFactory::getEditor();
 
 // clean any existing cache files

--- a/component/admin/views/icals/tmpl/overview.php
+++ b/component/admin/views/icals/tmpl/overview.php
@@ -12,7 +12,7 @@ defined('_JEXEC') or die('Restricted access');
 
 JHTML::_('behavior.tooltip');
 
-$db = JFactory::getDBO();
+$db = JFactory::getDbo();
 $user = JFactory::getUser();
 
 // get configuration object

--- a/component/admin/views/icals/view.html.php
+++ b/component/admin/views/icals/view.html.php
@@ -73,7 +73,7 @@ class AdminIcalsViewIcals extends JEventsAbstractView
 		if ($params->get("authorisedonly",0)){
 			// get authorised users
 			$sql = "SELECT u.* FROM #__jev_users as jev LEFT JOIN #__users as u on u.id=jev.user_id where jev.published=1 and jev.cancreate=1";
-			$db= JFactory::getDBO();
+			$db= JFactory::getDbo();
 			$db->setQuery( $sql );
 			$users = $db->loadObjectList();
 		}

--- a/component/admin/views/user/tmpl/overview.php
+++ b/component/admin/views/user/tmpl/overview.php
@@ -16,7 +16,7 @@ $option = JEV_COM_COMPONENT;
 $jinput = JFactory::getApplication()->input;
 
 $user = JFactory::getUser();
-$db = JFactory::getDBO();
+$db = JFactory::getDbo();
 $pathIMG = JURI::root() . 'administrator/images/';
 $orderdir = $jinput->getCmd("filter_order_Dir", 'asc');
 $order = $jinput->getCmd("filter_order", 'tl.id');

--- a/component/admin/views/user/view.html.php
+++ b/component/admin/views/user/view.html.php
@@ -83,7 +83,7 @@ class AdminUserViewUser extends JEventsAbstractView
 
 		$option = JRequest::getCmd('option', JEV_COM_COMPONENT);
 
-		$db = JFactory::getDBO();
+		$db = JFactory::getDbo();
 
 		$params = JComponentHelper::getParams(JEV_COM_COMPONENT);
 		$rules = JAccess::getAssetRules("com_jevents", true);

--- a/component/install.php
+++ b/component/install.php
@@ -103,7 +103,7 @@ class com_jeventsInstallerScript
 	
 	private function createTables() {
 
-		$db = JFactory::getDBO();
+		$db = JFactory::getDbo();
 		$db->setDebug(0);
 		if (version_compare(JVERSION, "3.3", 'ge')){
 			$charset = ($db->hasUTFSupport()) ?  ' DEFAULT CHARACTER SET `utf8`' : '';
@@ -450,7 +450,7 @@ SQL;
 		
 	private function updateTables() {
 
-		$db = JFactory::getDBO();
+		$db = JFactory::getDbo();
 		$db->setDebug(0);
 
 		if (version_compare(JVERSION, "3.3", 'ge')){

--- a/component/site/controllers/getjson.php
+++ b/component/site/controllers/getjson.php
@@ -108,7 +108,7 @@ class GetjsonController extends JControllerLegacy
 				. "\n AND m.id = " . $modid
 				. "\n AND m.access IN (" . JEVHelper::getAid($user, 'string') . ")"
 				. "\n AND m.client_id != 1";
-		$db = JFactory::getDBO();
+		$db = JFactory::getDbo();
 		$db->setQuery($query);
 		$modules = $db->loadObjectList();
 		if (count($modules) <= 0)

--- a/component/site/controllers/icals.php
+++ b/component/site/controllers/icals.php
@@ -29,7 +29,7 @@ class ICalsController extends AdminIcalsController
 		if ($cfg->get("disableicalexport", 0) && !$cfg->get("feimport", 0))
 		{
 	                 $query = "SELECT icsf.* FROM #__jevents_icsfile as icsf where icsf.autorefresh=1";
-			$db	= JFactory::getDBO();
+			$db	= JFactory::getDbo();
 			$db->setQuery($query);
 			$allICS = $db->loadObjectList();
 			if (count($allICS)==0){
@@ -340,7 +340,7 @@ class ICalsController extends AdminIcalsController
 		if ($jevuser && $jevuser->categories != "" && $jevuser->categories != "all")
 		{
 			// Find which categories to exclude
-			$db = JFactory::getDBO();
+			$db = JFactory::getDbo();
 			$catsql = 'SELECT id  FROM #__categories WHERE id NOT IN (' . str_replace("|", ",", $jevuser->categories) . ') AND extension="com_jevents"';
 			
 			$db->setQuery($catsql);
@@ -406,7 +406,7 @@ class ICalsController extends AdminIcalsController
 	function importdata()
 	{
 		// Check for request forgeries
-		JRequest::checkToken() or jexit('Invalid Token');
+		JSession::checkToken() or jexit('Invalid Token');
 
 		// Can only do this if can add an event
 		// Must be at least an event creator to edit or create events

--- a/component/site/controllers/modcal.php
+++ b/component/site/controllers/modcal.php
@@ -95,7 +95,7 @@ class ModCalController extends JControllerLegacy   {
 		. "\n AND m.id = ". $modid
 		. "\n AND m.access IN (" .  JEVHelper::getAid($user, 'string') . ")"
 		. "\n AND m.client_id != 1";
-		$db	= JFactory::getDBO();
+		$db	= JFactory::getDbo();
 		$db->setQuery( $query );
 		$modules = $db->loadObjectList();
 		if (count($modules)<=0){
@@ -204,7 +204,7 @@ class ModCalController extends JControllerLegacy   {
 		$user = JFactory::getUser();
 
 		$cfg = JEVConfig::getInstance();
-		$db	= JFactory::getDBO();
+		$db	= JFactory::getDbo();
 
 		$this->datamodel =new JEventsDataModel();
 

--- a/component/site/controllers/search.php
+++ b/component/site/controllers/search.php
@@ -44,7 +44,7 @@ class SearchController extends JControllerLegacy   {
 		$document = JFactory::getDocument();
 		$viewType	= $document->getType();
 
-		$db	= JFactory::getDBO();
+		$db	= JFactory::getDbo();
 		$keyword = $jinput->getString('keyword', '');
 		// limit searchword to a maximum of characters
 		$upper_limit = 20;
@@ -93,7 +93,7 @@ class SearchController extends JControllerLegacy   {
 		list($year,$month,$day) = JEVHelper::getYMD();
 		$Itemid	= JEVHelper::getItemid();
 
-		$db	= JFactory::getDBO();
+		$db	= JFactory::getDbo();
 		$keyword = JRequest::getString( 'keyword', '' );
 		// limit searchword to a maximum of characters
 		$upper_limit = 20;

--- a/component/site/jevents.php
+++ b/component/site/jevents.php
@@ -15,7 +15,7 @@ jimport('joomla.filesystem.path');
 
 // For development performance testing only
 /*
-  $db	= JFactory::getDBO();
+  $db	= JFactory::getDbo();
   $db->setQuery("SET SESSION query_cache_type = OFF");
   $db->execute();
 

--- a/component/site/libraries/commonfunctions.php
+++ b/component/site/libraries/commonfunctions.php
@@ -85,7 +85,7 @@ class JEV_CommonFunctions {
 
 		static $cats;
 		if (!isset($cats)){
-			$db	= JFactory::getDBO();
+			$db	= JFactory::getDbo();
 
 			$sql = "SELECT c.* FROM #__categories as c WHERE extension='".JEV_COM_COMPONENT."' order by c.lft asc";
 			$db->setQuery( $sql);
@@ -275,7 +275,7 @@ class JEV_CommonFunctions {
 
 		$params = JComponentHelper::getParams(JEV_COM_COMPONENT);
 
-		$db = JFactory::getDBO();
+		$db = JFactory::getDbo();
 		$cat = new JEventsCategory($db);
 		$cat->load($event->catid());
 		$adminuser = $cat->getAdminUser();

--- a/component/site/libraries/datamodel.php
+++ b/component/site/libraries/datamodel.php
@@ -228,7 +228,7 @@ class JEventsDataModel {
 		$data['year']=$year;
 		$data['month']=$month;
 
-		$db	= JFactory::getDBO();
+		$db	= JFactory::getDbo();
 
 		if (!isset($this->myItemid) || is_null($this->myItemid)) {
 			$Itemid = JEVHelper::getItemid();
@@ -524,7 +524,7 @@ class JEventsDataModel {
 		
 		$data = array();
 
-		$db	= JFactory::getDBO();
+		$db	= JFactory::getDbo();
 
 		$cfg = JEVConfig::getInstance();
 
@@ -567,7 +567,7 @@ class JEventsDataModel {
 
 		
 		$Itemid = JEVHelper::getItemid();
-		$db	= JFactory::getDBO();
+		$db	= JFactory::getDbo();
 
 		$cat = "";
 		if ($this->catidsOut != 0){
@@ -715,7 +715,7 @@ class JEventsDataModel {
 		
 		$pop = intval(JRequest::getVar( 'pop', 0 ));
 		$Itemid = JEVHelper::getItemid();
-		$db	= JFactory::getDBO();
+		$db	= JFactory::getDbo();
 		$user= JFactory::getUser();
 
 		$cfg = JEVConfig::getInstance();
@@ -853,7 +853,7 @@ class JEventsDataModel {
 			$user = isset($this->accessuser)? JEVHelper::getUser($this->accessuser) : JFactory::getUser();
 			if ($user->id==0)
 			{
-				$db=JFactory::getDBO();
+				$db=JFactory::getDbo();
 				$query = "SELECT ev.*"
 				. "\n FROM #__jevents_vevent as ev "
 				. "\n LEFT JOIN #__jevents_repetition as rpt ON rpt.eventid = ev.ev_id"
@@ -890,7 +890,7 @@ class JEventsDataModel {
 		$data = array();
 
 		$Itemid = JEVHelper::getItemid();
-		$db	= JFactory::getDBO();
+		$db	= JFactory::getDbo();
 		include_once(JPATH_ADMINISTRATOR."/components/".JEV_COM_COMPONENT."/libraries/colorMap.php");
 
 		$cfg = JEVConfig::getInstance();
@@ -952,7 +952,7 @@ class JEventsDataModel {
 		}
 		else if ((count($catids)==1 && $catids[0]!=0)  || (count($this->catids)==1 && $this->catids[0]!=0)  ){
 			// get the cat name from the database
-			$db	= JFactory::getDBO();
+			$db	= JFactory::getDbo();
 			$user = JFactory::getUser();
 			$catid = (count($catids)==1 && $catids[0]!=0)  ? intval($catids[0]) : $this->catids[0];
 			$catsql = 'SELECT c.title, c.description, c.id FROM #__categories AS c' .
@@ -995,7 +995,7 @@ class JEventsDataModel {
 
 		$user = JFactory::getUser();
 		$Itemid = JEVHelper::getItemid();
-		$db	= JFactory::getDBO();
+		$db	= JFactory::getDbo();
 
 		$cfg = JEVConfig::getInstance();
 
@@ -1072,7 +1072,7 @@ class JEventsDataModel {
 		$user = JFactory::getUser();
 		$Itemid = JEVHelper::getItemid();
 
-		$db	= JFactory::getDBO();		
+		$db	= JFactory::getDbo();
 
 		$cfg = JEVConfig::getInstance();
 

--- a/component/site/libraries/dbmodel.php
+++ b/component/site/libraries/dbmodel.php
@@ -75,7 +75,7 @@ class JEventsDBModel
 			$index = $aid . '+';
 		}
 
-		$db = JFactory::getDBO();
+		$db = JFactory::getDbo();
 
 		$where = "";
 
@@ -188,7 +188,7 @@ class JEventsDBModel
 	function getCategoryInfo($catids = null, $aid = null)
 	{
 
-		$db = JFactory::getDBO();
+		$db = JFactory::getDbo();
 		if (is_null($aid))
 		{
 			$aid = $this->datamodel->aid;
@@ -243,7 +243,7 @@ class JEventsDBModel
 	function getChildCategories($catids = null, $levels = 1, $aid = null)
 	{
 
-		$db = JFactory::getDBO();
+		$db = JFactory::getDbo();
 		if (is_null($aid))
 		{
 			$aid = $this->datamodel->aid;
@@ -307,7 +307,7 @@ class JEventsDBModel
 	function recentIcalEvents($startdate, $enddate, $limit = 10, $repeatdisplayoptions = 0)
 	{
 		$user = JFactory::getUser();
-		$db = JFactory::getDBO();
+		$db = JFactory::getDbo();
 		$lang = JFactory::getLanguage();
 		$langtag = $lang->getTag();
 
@@ -401,7 +401,7 @@ class JEventsDBModel
 		$query .= " LIMIT " . $limit;
 
 
-		$db = JFactory::getDBO();
+		$db = JFactory::getDbo();
 		$db->setQuery($query);
 		$ids = $db->loadColumn();
 		array_push($ids, 0);
@@ -478,7 +478,7 @@ class JEventsDBModel
 	function recentlyModifiedIcalEvents($startdate, $enddate, $limit = 10, $repeatdisplayoptions = 0)
 	{
 		$user = JFactory::getUser();
-		$db = JFactory::getDBO();
+		$db = JFactory::getDbo();
 		$lang = JFactory::getLanguage();
 		$langtag = $lang->getTag();
 
@@ -571,7 +571,7 @@ class JEventsDBModel
 		$query .= " LIMIT " . $limit;
 
 
-		$db = JFactory::getDBO();
+		$db = JFactory::getDbo();
 		$db->setQuery($query);
 //echo "<pre>".$db->getQuery()."</pre>";exit();
 		$detids = $db->loadColumn();
@@ -648,7 +648,7 @@ class JEventsDBModel
 	function popularIcalEvents($startdate, $enddate, $limit = 10, $repeatdisplayoptions = 0, $multidayTreatment = 0)
 	{
 		$user = JFactory::getUser();
-		$db = JFactory::getDBO();
+		$db = JFactory::getDbo();
 		$lang = JFactory::getLanguage();
 		$langtag = $lang->getTag();
 
@@ -802,7 +802,7 @@ class JEventsDBModel
 		$query .= " LIMIT " . $limit;
 
 
-		$db = JFactory::getDBO();
+		$db = JFactory::getDbo();
 		$db->setQuery($query);
 		$ids = $db->loadColumn();
 		array_push($ids, 0);
@@ -2281,7 +2281,7 @@ class JEventsDBModel
 		$starttime = (float) $usec + (float) $sec;
 
 		$user = JFactory::getUser();
-		$db = JFactory::getDBO();
+		$db = JFactory::getDbo();
 		$lang = JFactory::getLanguage();
 		$langtag = $lang->getTag();
 
@@ -2403,7 +2403,7 @@ class JEventsDBModel
 				$query .= " LIMIT " . $limit;
 			}
 
-			$db = JFactory::getDBO();
+			$db = JFactory::getDbo();
 			$db->setQuery($query);
 			$rptids = $db->loadColumn();
 
@@ -2497,7 +2497,7 @@ class JEventsDBModel
 			}
 
 			if ($debuginfo){
-				$db = JFactory::getDBO();
+				$db = JFactory::getDbo();
 				$db->setQuery($query);
 				$rows = $db->loadObjectList();
 				list ($usec, $sec) = explode(" ", microtime());
@@ -2545,7 +2545,7 @@ class JEventsDBModel
 		$starttime = (float) $usec + (float) $sec;
 
 		$user = JFactory::getUser();
-		$db = JFactory::getDBO();
+		$db = JFactory::getDbo();
 		$adminuser = JEVHelper::isAdminUser($user);
 		$db->setQuery($query);
 		if ($adminuser)
@@ -2717,7 +2717,7 @@ select @@sql_mode;
 		}
 
 		$user = JFactory::getUser();
-		$db = JFactory::getDBO();
+		$db = JFactory::getDbo();
 		$lang = JFactory::getLanguage();
 		$langtag = $lang->getTag();
 
@@ -2874,7 +2874,7 @@ select @@sql_mode;
 		{
 			$user = JFactory::getUser();
 		}
-		$db = JFactory::getDBO();
+		$db = JFactory::getDbo();
 		$lang = JFactory::getLanguage();
 		$langtag = $lang->getTag();
 
@@ -3028,7 +3028,7 @@ select @@sql_mode;
 
 		if ($count)
 		{
-			$db = JFactory::getDBO();
+			$db = JFactory::getDbo();
 			$db->setQuery($query);
 			$res = $db->loadResult();
 			return $res;
@@ -3181,7 +3181,7 @@ select @@sql_mode;
 		}
 
 		$user = JFactory::getUser();
-		$db = JFactory::getDBO();
+		$db = JFactory::getDbo();
 		$frontendPublish = JEVHelper::isEventPublisher();
 
 		if ($jevtype == "icaldb")
@@ -3306,7 +3306,7 @@ select @@sql_mode;
 	function getEventById($evid, $includeUnpublished = 0, $jevtype = "icaldb", $checkAccess=true)
 	{
 		$user = JFactory::getUser();
-		$db = JFactory::getDBO();
+		$db = JFactory::getDbo();
 
 		$frontendPublish = JEVHelper::isEventPublisher();
 
@@ -3426,7 +3426,7 @@ select @@sql_mode;
 	function listIcalEventsByCreator($creator_id, $limitstart, $limit, $orderby = 'dtstart ASC')
 	{
 		$user = JFactory::getUser();
-		$db = JFactory::getDBO();
+		$db = JFactory::getDbo();
 
 		$cfg = JEVConfig::getInstance();
 
@@ -3553,7 +3553,7 @@ select @@sql_mode;
 		}
 
 		$user = JFactory::getUser();
-		$db = JFactory::getDBO();
+		$db = JFactory::getDbo();
 
 		$cfg = JEVConfig::getInstance();
 
@@ -3745,7 +3745,7 @@ select @@sql_mode;
 	function countIcalEventsByCreator($creator_id)
 	{
 		$user = JFactory::getUser();
-		$db = JFactory::getDBO();
+		$db = JFactory::getDbo();
 
 		$extrawhere = array();
 		$extrajoin = array();
@@ -3826,7 +3826,7 @@ select @@sql_mode;
 	function countIcalEventRepeatsByCreator($creator_id)
 	{
 		$user = JFactory::getUser();
-		$db = JFactory::getDBO();
+		$db = JFactory::getDbo();
 
 		$extrawhere = array();
 		$extrajoin = array();
@@ -3901,7 +3901,7 @@ select @@sql_mode;
 	public function listIcalEventsByCat($catids, $showrepeats = false, $total = 0, $limitstart = 0, $limit = 0, $order = "rpt.startrepeat asc, rpt.endrepeat ASC, det.summary ASC", $filters = false, $extrafields = "", $extratables = "")
 	{
             
-		$db = JFactory::getDBO();
+		$db = JFactory::getDbo();
 		$user = JFactory::getUser();
 
 		// Use catid in accessibleCategoryList to pick up offsping too!
@@ -4072,7 +4072,7 @@ select @@sql_mode;
 
 	function countIcalEventsByCat($catids, $showrepeats = false)
 	{
-		$db = JFactory::getDBO();
+		$db = JFactory::getDbo();
 		$user = JFactory::getUser();
 
 		// Use catid in accessibleCategoryList to pick up offsping too!
@@ -4197,7 +4197,7 @@ select @@sql_mode;
 	{
 		$user = JFactory::getUser();
 		$adminuser = JEVHelper::isAdminUser($user);
-		$db = JFactory::getDBO();
+		$db = JFactory::getDbo();
 		
 		$keyword = $db->escape($keyword, true) ;
 
@@ -4419,7 +4419,7 @@ select @@sql_mode;
 		$start = $year . '/' . $month . '/' . $day . ' 00:00:00';
 		$end = $year . '/' . $month . '/' . $day . ' 23:59:59';
 
-		$db = JFactory::getDBO();
+		$db = JFactory::getDbo();
 		$query = "SELECT ev.*, rpt.* "
 				. "\n FROM #__jevents_vevent as ev"
 				. "\n LEFT JOIN #__jevents_repetition as rpt ON rpt.eventid = ev.ev_id"
@@ -4436,7 +4436,7 @@ select @@sql_mode;
 		}
 
 		// still no match so find the nearest repeat and give a message.
-		$db = JFactory::getDBO();
+		$db = JFactory::getDbo();
 		$query = "SELECT ev.*, rpt.*, abs(datediff(rpt.startrepeat," . $db->Quote($start) . ")) as diff "
 				. "\n FROM #__jevents_repetition as rpt"
 				. "\n INNER JOIN #__jevents_vevent as ev ON rpt.eventid = ev.ev_id"
@@ -4462,7 +4462,7 @@ select @@sql_mode;
 		$params = JComponentHelper::getParams("com_jevents");
 		if ($params->get("multicategory", 0))
 		{
-			$db = JFactory::getDBO();
+			$db = JFactory::getDbo();
 			// get list of categories this event is in - are they all accessible?
 			$db->setQuery("SELECT catid FROM #__jevents_catmap WHERE evid=" . $row->ev_id);
 			$catids = $db->loadColumn();

--- a/component/site/libraries/filters/Category.php
+++ b/component/site/libraries/filters/Category.php
@@ -51,7 +51,7 @@ class jevCategoryFilter extends jevFilter
 		/*
 		$sectionname = JEV_COM_COMPONENT;
 		
-		$db = JFactory::getDBO();
+		$db = JFactory::getDbo();
 		$q_published = JFactory::getApplication()->isAdmin() ? "\n WHERE c.published >= 0" : "\n WHERE c.published = 1";
 		$where = ' AND (c.id =' . $this->filter_value .' OR p.id =' . $this->filter_value .' OR gp.id =' . $this->filter_value .' OR ggp.id =' . $this->filter_value .')';		
 		$query = "SELECT c.id"

--- a/component/site/libraries/filters/Search.php
+++ b/component/site/libraries/filters/Search.php
@@ -36,7 +36,7 @@ class jevSearchFilter extends jevFilter
 		if (!$this->filterField ) return "";
 		if (trim($this->filter_value)==$this->filterNullValue) return "";
 
-		$db = JFactory::getDBO();
+		$db = JFactory::getDbo();
 		$text = $db->Quote( '%'.$db->escape( $this->filter_value, true ).'%', false );
 		
 		$filter = "(det.summary LIKE $text OR det.description LIKE $text OR det.extra_info LIKE $text)";
@@ -49,7 +49,7 @@ class jevSearchFilter extends jevFilter
 		$dispatcher = JEventDispatcher::getInstance();
 		$dispatcher->trigger('onSearchEvents', array(& $this->extrasearchfields, & $this->extrajoin, & $this->needsgroup));			
 		
-		$db = JFactory::getDBO();
+		$db = JFactory::getDbo();
 		$keyword = $db->Quote( '%'.$db->escape( $this->filter_value, true ).'%', false );
 		$text = $db->escape( $this->filter_value, true );
 							
@@ -86,7 +86,7 @@ class jevSearchFilter extends jevFilter
 
 		if (!$this->filterField) return "";
 
-		$db = JFactory::getDBO();
+		$db = JFactory::getDbo();
 				
 		$filterList=array();
 		$filterList["title"]="<label class='evsearch_label' for='".$this->filterType."_fv'>".$this->filterLabel."</label>";

--- a/component/site/libraries/gwejson_checkconflict.php
+++ b/component/site/libraries/gwejson_checkconflict.php
@@ -77,7 +77,7 @@ function ProcessJsonRequest(&$requestObject, $returnData){
 
 	if (intval($requestObject->formdata->evid) > 0)
 	{
-		$db = JFactory::getDBO();
+		$db = JFactory::getDbo();
 		$dataModel = new JEventsDataModel("JEventsAdminDBModel");
 		$queryModel = new JEventsDBModel($dataModel);
 		$event = $queryModel->getEventById(intval($requestObject->formdata->evid), 1, "icaldb");
@@ -240,7 +240,7 @@ function simulateSaveRepeat($requestObject)
 		PlgSystemGwejson::throwerror(JText::_('ALERTNOTAUTH'));
 	}
 
-	$db = JFactory::getDBO();
+	$db = JFactory::getDbo();
 	$rpt = new iCalRepetition($db);
 	$rpt->load($rp_id);
 
@@ -339,7 +339,7 @@ function valueIfExists($array, $key, $default)
 function checkEventOverlaps($testevent, & $returnData, $eventid, $requestObject)
 {
 	$params = JComponentHelper::getParams("com_jevents");
-	$db = JFactory::getDBO();
+	$db = JFactory::getDbo();
 	$overlaps = array();
 
 
@@ -492,7 +492,7 @@ function checkEventOverlaps($testevent, & $returnData, $eventid, $requestObject)
 function checkRepeatOverlaps($repeat, & $returnData, $eventid, $requestObject)
 {
 	$params = JComponentHelper::getParams("com_jevents");
-	$db = JFactory::getDBO();
+	$db = JFactory::getDbo();
 	$overlaps = array();
 	if ( $params->get("checkconflicts", 0) == 2 )
 	{

--- a/component/site/libraries/gwejson_findcreator.php
+++ b/component/site/libraries/gwejson_findcreator.php
@@ -31,7 +31,7 @@ function ProcessJsonRequest(&$requestObject, $returnData){
 	//$access = JAccess::check($user->id, "core.deleteall", "com_jevents");
 	$access = $user->authorise('core.admin', 'com_jevents') || $user->authorise('core.deleteall', 'com_jevents');
 
-	$db = JFactory::getDBO();
+	$db = JFactory::getDbo();
 	if (!($jevuser && $jevuser->candeleteall) &&  !$access)
 	{
 		PlgSystemGwejson::throwerror("There was an error - no access");
@@ -47,7 +47,7 @@ function ProcessJsonRequest(&$requestObject, $returnData){
 		PlgSystemGwejson::throwerror ( "There was an error - no valid argument");
 	}
 
-	$db = JFactory::getDBO();
+	$db = JFactory::getDbo();
 
 	$title = JFilterInput::getInstance()->clean($requestObject->typeahead,"string");
 	$text  = $db->Quote( '%'.$db->escape( $title, true ).'%', false );

--- a/component/site/libraries/helper.php
+++ b/component/site/libraries/helper.php
@@ -1172,7 +1172,7 @@ class JEVHelper
 				// Check maxevent count
 				if ($user->eventslimit > 0)
 				{
-					$db = JFactory::getDBO();
+					$db = JFactory::getDbo();
 					$db->setQuery("SELECT count(*) FROM #__jevents_vevent where created_by=" . $user->user_id);
 					$eventcount = intval($db->loadResult());
 					if ($eventcount < $user->eventslimit)
@@ -1793,7 +1793,7 @@ class JEVHelper
 			return false;
 		$juser = JFactory::getUser();
 
-		$db = JFactory::getDBO();
+		$db = JFactory::getDbo();
                 // TODO make this query tighter to stop uers with ids starting with $juser->id from matching -
                 // try using word boundaries RLIKE [[:<:]] and [[;>:]]  see http://dev.mysql.com/doc/refman/5.7/en/regexp.html
 		$sql = "SELECT id FROM #__categories WHERE extension='com_jevents' AND params like ('%\"admin\":\"" . $juser->id . "\"%')";
@@ -2116,7 +2116,7 @@ class JEVHelper
 			function getContact($id, $attrib = 'Object')
 	{
 
-		$db = JFactory::getDBO();
+		$db = JFactory::getDbo();
 
 		static $rows = array();
 
@@ -2332,7 +2332,7 @@ class JEVHelper
 			if (!$rootlevels)
 			{
 				// Get a database object.
-				$db = JFactory::getDBO();
+				$db = JFactory::getDbo();
 
 				// Build the base query.
 				$query = $db->getQuery(true);
@@ -2525,7 +2525,7 @@ class JEVHelper
 			else
 			{
 				// Get a database object.
-				$db = JFactory::getDBO();
+				$db = JFactory::getDbo();
 
 				// Set the query for execution.
 				$db->setQuery("SELECT id FROM #__viewlevels order by ordering limit 1");
@@ -3138,7 +3138,7 @@ SCRIPT;
 				$ids[] = $a->ev_id();
 				if (count($ids) > 100)
 				{
-					$db = JFactory::getDBO();
+					$db = JFactory::getDbo();
 					$db->setQuery("SELECT * FROM #__jevents_exception where eventid IN (" . implode(",", $ids) . ")");
 					$rows = $db->loadObjectList();
 					foreach ($rows as $row)
@@ -3155,7 +3155,7 @@ SCRIPT;
 			// mop up the last ones
 			if (count($ids) > 0)
 			{
-				$db = JFactory::getDBO();
+				$db = JFactory::getDbo();
 				$db->setQuery("SELECT * FROM #__jevents_exception where eventid IN (" . implode(",", $ids) . ")");
 				$rows = $db->loadObjectList();
 				foreach ($rows as $row)

--- a/component/site/libraries/iCalEvent.php
+++ b/component/site/libraries/iCalEvent.php
@@ -115,7 +115,7 @@ class iCalEvent extends JTable  {
 		// place private reference to created_by in event detail in case needed by plugins
 		$this->_detail->_created_by = $this->created_by ;
 				
-		$db = JFactory::getDBO();
+		$db = JFactory::getDbo();
 		$detailid = $this->_detail->store($updateNulls);
 
 		if (!$detailid){
@@ -222,7 +222,7 @@ class iCalEvent extends JTable  {
 	 * @return n/a
 	 */
 	public static function iCalEventFromData($ice){
-		$db	= JFactory::getDBO();
+		$db	= JFactory::getDbo();
 		$temp = new iCalEvent($db);
 		$temp->data = $ice;
 		if (array_key_exists("RRULE",$temp->data)){
@@ -242,7 +242,7 @@ class iCalEvent extends JTable  {
 	 * @return n/a
 	 */
 	public static function iCalEventFromDB($icalrowAsArray){
-		$db	= JFactory::getDBO();
+		$db	= JFactory::getDbo();
 		$temp = new iCalEvent($db);
 		foreach ($icalrowAsArray as $key=>$val) {
 			$temp->$key = $val;
@@ -365,7 +365,7 @@ else $this->_detail = false;
 		}
 		// if no rrule then only one instance
 		if (!isset($this->rrule)  || strtolower($this->rrule->freq)=="none" ){
-			$db	= JFactory::getDBO();
+			$db	= JFactory::getDbo();
 			$repeat = new iCalRepetition($db);
 			$repeat->eventid = $this->ev_id;
                         // is it in a non-default timezone?
@@ -424,7 +424,7 @@ else $this->_detail = false;
 
 		// TODO if I implement this outsite of upload I need to clean the detail table too
 		$duplicatecheck = md5($eventid . $start);
-		$db	= JFactory::getDBO();
+		$db	= JFactory::getDbo();
 		$sql = "DELETE FROM #__jevents_repetition WHERE duplicatecheck='".$duplicatecheck."'";
 		$db->setQuery($sql);
 		return $db->execute();
@@ -447,7 +447,7 @@ else $this->_detail = false;
 		$duplicatecheck = md5($eventid . $start );
 
 		// find the existing repetition in order to get the detailid
-		$db	= JFactory::getDBO();
+		$db	= JFactory::getDbo();
 		$sql = "SELECT * FROM #__jevents_repetition WHERE duplicatecheck='$duplicatecheck'";
 		$db->setQuery($sql);
 		$matchingRepetition=$db->loadObject();
@@ -484,7 +484,7 @@ else $this->_detail = false;
 		}
 
 		$duplicatecheck = md5($eventid . $start );
-		$db	= JFactory::getDBO();
+		$db	= JFactory::getDbo();
 		$sql = "UPDATE #__jevents_repetition SET eventdetail_id=".$newDetail->evdet_id
 		.", startrepeat='".$start."'"
 		.", endrepeat='".$end."'"
@@ -498,7 +498,7 @@ else $this->_detail = false;
 	function storeRepetitions() {
 		if (!isset($this->_repetitions)) $this->getRepetitions(true);
 		if (count($this->_repetitions)==0) return false;
-		$db	= JFactory::getDBO();
+		$db	= JFactory::getDbo();
 		// I must delete the eventdetails for repetitions not matching the global event detail
 		// these will be recreated later to match the new adjusted repetitions
 

--- a/component/site/libraries/iCalEventDetail.php
+++ b/component/site/libraries/iCalEventDetail.php
@@ -96,7 +96,7 @@ class iCalEventDetail extends JTable  {
 	 * @return n/a
 	 */
 	public static function iCalEventDetailFromData($ice){
-		$db	= JFactory::getDBO();
+		$db	= JFactory::getDbo();
 		$temp = new iCalEventDetail($db);
 		$temp->_data = $ice;
 		$temp->convertData();
@@ -111,7 +111,7 @@ class iCalEventDetail extends JTable  {
 	 * @return n/a
 	 */
 	public static function iCalEventDetailFromDB($icalrowAsArray){
-		$db	= JFactory::getDBO();
+		$db	= JFactory::getDbo();
 		$temp = new iCalEventDetail($db);
 		$temp->_data = $icalrowAsArray;
 		$temp->convertData();
@@ -193,7 +193,7 @@ class iCalEventDetail extends JTable  {
 		// The description and summary may need escaping !!!
 		// But this will be done by the SQL update function as part of the store so don't do it twice
 		/*
-		$db = JFactory::getDBO();
+		$db = JFactory::getDbo();
 		$this->description = $db->escape($this->description);
 		$this->summary = $db->escape($this->summary);
 		*/

--- a/component/site/libraries/iCalException.php
+++ b/component/site/libraries/iCalException.php
@@ -36,7 +36,7 @@ class iCalException extends JTable  {
 
 	public static function loadByRepeatId($rp_id){
 		
-		$db = JFactory::getDBO();
+		$db = JFactory::getDbo();
 		$sql = "SELECT * FROM #__jevents_exception WHERE rp_id=".intval($rp_id);
 		$db->setQuery($sql);
 		$data = $db->loadObject();

--- a/component/site/libraries/iCalICSFile.php
+++ b/component/site/libraries/iCalICSFile.php
@@ -70,7 +70,7 @@ class iCalICSFile extends JTable  {
 	}
 
 	public function editICalendar($icsid,$catid,$access=0,$state=1, $label=""){
-		$db	= JFactory::getDBO();
+		$db	= JFactory::getDbo();
 		$temp = new iCalICSFile($db);
 		$temp->_setup($icsid,$catid,$access,$state);
 		$temp->filename="_from_scratch_";
@@ -112,7 +112,7 @@ RAWTEXT;
 	}
 
 	public static function newICSFileFromURL($uploadURL,$icsid,$catid,$access=0,$state=1, $label="", $autorefresh=0, $ignoreembedcat=0){
-		$db	= JFactory::getDBO();
+		$db	= JFactory::getDbo();
 		$temp = new iCalICSFile($db);
 		$temp->_setup($icsid,$catid,$access,$state,$autorefresh,$ignoreembedcat);
 		if ($access==0){
@@ -161,7 +161,7 @@ RAWTEXT;
 	}
 
 	public static function newICSFileFromFile($file,$icsid,$catid,$access=0,$state=1, $label="", $autorefresh=0, $ignoreembedcat=0){
-		$db	= JFactory::getDBO();
+		$db	= JFactory::getDbo();
 		$temp = new iCalICSFile($db);
 		$temp->_setup($icsid,$catid,$access,$state,$autorefresh,$ignoreembedcat);
 		if ($access==0){
@@ -185,7 +185,7 @@ RAWTEXT;
 	 * Used to create Ical from raw strring
 	 */
 	public function newICSFileFromString($rawtext,$icsid,$catid,$access=0,$state=1, $label="", $autorefresh=0, $ignoreembedcat=0){
-		$db	= JFactory::getDBO();
+		$db	= JFactory::getDbo();
 		$temp = null;
 		$temp = new iCalICSFile($db);
 		if ($icsid>0){
@@ -214,7 +214,7 @@ RAWTEXT;
 	public function updateDetails(){
 		if (parent::store() && $this->isdefault==1 && $this->icaltype==2){
 			// set all the others to 0
-			$db	= JFactory::getDBO();
+			$db	= JFactory::getDbo();
 			$sql = "UPDATE #__jevents_icsfile SET isdefault=0 WHERE icaltype=2 AND ics_id<>".$this->ics_id;
 			$db->setQuery($sql);
 			$db->execute();
@@ -241,7 +241,7 @@ RAWTEXT;
 		static $categories;
 		if (is_null($categories)){
 			$sql = "SELECT * FROM #__categories WHERE extension='com_jevents'";
-			$db	= JFactory::getDBO();
+			$db	= JFactory::getDbo();
 			$db->setQuery($sql);
 			$categories = $db->loadObjectList('title');
 		}
@@ -261,14 +261,14 @@ RAWTEXT;
 		}
 		else if ($this->isdefault==1 && $this->icaltype==2){
 			// set all the others to 0
-			$db	= JFactory::getDBO();
+			$db	= JFactory::getDbo();
 			$sql = "UPDATE #__jevents_icsfile SET isdefault=0 WHERE icaltype=2 AND ics_id<>".$this->ics_id;
 			$db->setQuery($sql);
 			$db->execute();
 		}
 
 		// find the full set of ids currently in the calendar so taht we can remove cancelled ones
-		$db	= JFactory::getDBO();
+		$db	= JFactory::getDbo();
 		$sql = "SELECT ev_id, uid, lockevent FROM #__jevents_vevent WHERE icsid=".$this->ics_id ;//. " AND catid=".$catid;
 		$db->setQuery($sql);
 		$existingevents = $db->loadObjectList('ev_id');
@@ -534,7 +534,7 @@ RAWTEXT;
 		
 		static $categories;
 		if (is_null($categories)){
-			$db	= JFactory::getDBO();
+			$db	= JFactory::getDbo();
 			$sql = "SELECT * FROM #__categories WHERE extension='com_jevents'";
 			$db->setQuery($sql);
 			$categories = $db->loadObjectList('title');

--- a/component/site/libraries/iCalRRule.php
+++ b/component/site/libraries/iCalRRule.php
@@ -47,7 +47,7 @@ class iCalRRule extends JTable  {
 	 * @return n/a
 	 */
 	public function iCalRRuleFromDB($icalrowAsArray){
-		$db	= JFactory::getDBO();
+		$db	= JFactory::getDbo();
 		$temp = new iCalRRule($db);
 
 		$temp->data = $icalrowAsArray;
@@ -97,7 +97,7 @@ class iCalRRule extends JTable  {
 	 * @return n/a
 	 */
 	public static  function iCalRRuleFromData($rrule){
-		$db	= JFactory::getDBO();
+		$db	= JFactory::getDbo();
 		$temp = new iCalRRule($db);
 
 		$temp->data = $rrule;
@@ -152,7 +152,7 @@ class iCalRRule extends JTable  {
 	 */
 	public function _makeRepeat($start,$end){
 		if (!isset($this->_repetitions)) $this->_repetitions = array();
-		$db	= JFactory::getDBO();
+		$db	= JFactory::getDbo();
 		$repeat = new iCalRepetition($db);
 		$repeat->eventid = $this->eventid;
 		// TODO CHECK THIS logic

--- a/component/site/libraries/jeventcal.php
+++ b/component/site/libraries/jeventcal.php
@@ -329,7 +329,7 @@ class jEventCal {
 		static $arr_catids;
 
 		if (!isset($arr_catids)) {
-			$db	= JFactory::getDBO();
+			$db	= JFactory::getDbo();
 			$arr_catids = array();
 			$catsql = "SELECT cat.id, cat.title as name, pcat.title as pname, cat.description, cat.params  FROM #__categories  as cat LEFT JOIN #__categories as pcat on pcat.id=cat.parent_id WHERE cat.extension='com_jevents' ORDER BY cat.lft" ;
 			$db->setQuery($catsql);

--- a/component/site/libraries/jeventshtml.php
+++ b/component/site/libraries/jeventshtml.php
@@ -529,7 +529,7 @@ class JEventsHTML
 	    public static function getUserMailtoLink($evid, $userid, $admin = false, $event)
 	    {
 
-		    $db = JFactory::getDBO();
+		    $db = JFactory::getDbo();
 
 		    static $arr_userids;
 		    static $arr_evids;
@@ -602,7 +602,7 @@ class JEventsHTML
 				    $anonplugin = JPluginHelper::getPlugin("jevents", "jevanonuser");
 				    if ($anonplugin)
 				    {
-					    $db = JFactory::getDBO();
+					    $db = JFactory::getDbo();
 					    $db->setQuery("SELECT a.* FROM #__jev_anoncreator as a LEFT JOIN #__jevents_repetition as r on a.ev_id=r.eventid where r.rp_id=" . intval($evid) . " LIMIT 1");
 					    $anonrow = $db->loadObject();
 					    if ($anonrow)
@@ -651,7 +651,7 @@ class JEventsHTML
 
 	    public static function getColorBar($event_id = null, $newcolor)
 	    {
-		    $db = JFactory::getDBO();
+		    $db = JFactory::getDbo();
 
 		    $cfg = JEVConfig::getInstance();
 

--- a/component/site/libraries/jicaleventdb.php
+++ b/component/site/libraries/jicaleventdb.php
@@ -508,7 +508,7 @@ class jIcalEventDB extends jEventCal {
 	}
 
 	function getCalendarName( ){
-		$db	= JFactory::getDBO();
+		$db	= JFactory::getDbo();
 
 		static $arr_calids;
 
@@ -650,7 +650,7 @@ class jIcalEventDB extends jEventCal {
 	// Gets repeats for this event from databases
 	function getFirstRepeat($allowexceptions=true){
 
-		$db = JFactory::getDBO();
+		$db = JFactory::getDbo();
 		$query = "SELECT ev.*, rpt.*, rr.*, det.* "
 		. "\n , YEAR(rpt.startrepeat) as yup, MONTH(rpt.startrepeat ) as mup, DAYOFMONTH(rpt.startrepeat ) as dup"
 		. "\n , YEAR(rpt.endrepeat  ) as ydn, MONTH(rpt.endrepeat   ) as mdn, DAYOFMONTH(rpt.endrepeat   ) as ddn"
@@ -679,7 +679,7 @@ class jIcalEventDB extends jEventCal {
 	// Gets repeats for this event from databases
 	function getLastRepeat($allowexceptions=true){
 
-		$db = JFactory::getDBO();
+		$db = JFactory::getDbo();
 		$query = "SELECT ev.*, rpt.*, rr.*, det.* "
 		. "\n , YEAR(rpt.startrepeat) as yup, MONTH(rpt.startrepeat ) as mup, DAYOFMONTH(rpt.startrepeat ) as dup"
 		. "\n , YEAR(rpt.endrepeat  ) as ydn, MONTH(rpt.endrepeat   ) as mdn, DAYOFMONTH(rpt.endrepeat   ) as ddn"
@@ -710,7 +710,7 @@ class jIcalEventDB extends jEventCal {
 
 		$t_datenow = JEVHelper::getNow();
 		$now = $t_datenow->toMysql();
-		$db = JFactory::getDBO();
+		$db = JFactory::getDbo();
 		$query = "SELECT ev.*, rpt.*, rr.*, det.* "
 		. "\n , YEAR(rpt.startrepeat) as yup, MONTH(rpt.startrepeat ) as mup, DAYOFMONTH(rpt.startrepeat ) as dup"
 		. "\n , YEAR(rpt.endrepeat  ) as ydn, MONTH(rpt.endrepeat   ) as mdn, DAYOFMONTH(rpt.endrepeat   ) as ddn"
@@ -779,7 +779,7 @@ class jIcalEventDB extends jEventCal {
 		$extrajoin = ( count( $extrajoin  ) ?  " \n LEFT JOIN ".implode( " \n LEFT JOIN ", $extrajoin ) : '' );
 		$extrawhere = ( count( $extrawhere ) ? ' AND '. implode( ' AND ', $extrawhere ) : '' );
 
-		$db = JFactory::getDBO();
+		$db = JFactory::getDbo();
 		$query = "SELECT ev.*, rpt.*, rr.*, det.* $extrafields , ev.state as state,  ev.state as published"
 		. "\n , YEAR(rpt.startrepeat) as yup, MONTH(rpt.startrepeat ) as mup, DAYOFMONTH(rpt.startrepeat ) as dup"
 		. "\n , YEAR(rpt.endrepeat  ) as ydn, MONTH(rpt.endrepeat   ) as mdn, DAYOFMONTH(rpt.endrepeat   ) as ddn"
@@ -823,7 +823,7 @@ class jIcalEventDB extends jEventCal {
 		}
 		$done[$this->evdet_id()]=1;
 
-		$db = JFactory::getDBO();
+		$db = JFactory::getDbo();
 
 		// Should this happen here?
 		$query = "UPDATE #__jevents_vevdetail SET hits=(hits+1) WHERE evdet_id='".$this->evdet_id()."'"	;
@@ -867,7 +867,7 @@ class jIcalEventDB extends jEventCal {
 		
 		$this->dtfixed = 1;
 		
-		$db = JFactory::getDBO();
+		$db = JFactory::getDbo();
 
 		// Now get the first repeat since dtstart may have been set in a different timezeone and since it is a unixdate it would then be wrong
 		if (strtolower($this->freq())=="none"){

--- a/component/site/libraries/jicaleventrepeat.php
+++ b/component/site/libraries/jicaleventrepeat.php
@@ -401,7 +401,7 @@ class jIcalEventRepeat extends jIcalEventDB
 		$Itemid = JEVHelper::getItemid();
 		list($year, $month, $day) = JEVHelper::getYMD();
 
-		$db = JFactory::getDBO();
+		$db = JFactory::getDbo();
 
 		$sql = "SELECT rpt.*,det.summary as title , YEAR(rpt.startrepeat) as yup, MONTH(rpt.startrepeat ) as mup, DAYOFMONTH(rpt.startrepeat ) as dup FROM #__jevents_repetition  as rpt
 			 LEFT JOIN #__jevents_vevdetail as det ON det.evdet_id = rpt.eventdetail_id WHERE rpt.eventid=" . $this->ev_id() . " AND rpt.rp_id <> " . $this->rp_id() . " AND rpt.startrepeat<='" . $this->_startrepeat . "' ORDER BY rpt.startrepeat DESC limit 1";

--- a/component/site/libraries/modfunctions.php
+++ b/component/site/libraries/modfunctions.php
@@ -19,7 +19,7 @@ use Joomla\String\StringHelper;
 function findAppropriateMenuID (&$catidsOut, &$modcatids, &$catidList, $modparams, &$showall){
 	// Itemid, search for menuid with lowest access rights
 	$user = JFactory::getUser();
-	$db	= JFactory::getDBO();
+	$db	= JFactory::getDbo();
 	$jinput = JFactory::getApplication()->input;
 
 	// Do we ignore category filters?

--- a/component/site/views/default/helpers/defaultloadedfromtemplate.php
+++ b/component/site/views/default/helpers/defaultloadedfromtemplate.php
@@ -5,7 +5,7 @@ use Joomla\String\StringHelper;
 
 function DefaultLoadedFromTemplate($view, $template_name, $event, $mask, $template_value = false, $runplugins = true)
 {
-	$db = JFactory::getDBO();
+	$db = JFactory::getDbo();
 	static $allcatids;
 	if (!isset($allcatids))
 	{
@@ -470,7 +470,7 @@ function DefaultLoadedFromTemplate($view, $template_name, $event, $mask, $templa
 
 				    if (!isset($allcat_catids))
 				    {
-					    $db = JFactory::getDBO();
+					    $db = JFactory::getDbo();
 					    $arr_catids = array();
 					    $catsql = "SELECT cat.id, cat.title as name, cat.params FROM #__categories  as cat WHERE cat.extension='com_jevents' ";
 					    $db->setQuery($catsql);
@@ -677,7 +677,7 @@ function DefaultLoadedFromTemplate($view, $template_name, $event, $mask, $templa
 				    $search[] = "{{ALLCATEGORYIMGS}}";
 				    if (!isset($allcat_catids))
 				    {
-					    $db = JFactory::getDBO();
+					    $db = JFactory::getDbo();
 					    $arr_catids = array();
 					    $catsql = "SELECT cat.id, cat.title as name, cat.params FROM #__categories  as cat WHERE cat.extension='com_jevents' ";
 					    $db->setQuery($catsql);

--- a/component/site/views/icals/tmpl/export.php
+++ b/component/site/views/icals/tmpl/export.php
@@ -44,7 +44,7 @@ if (!empty($this->icalEvents))
 		$ids[] = $a->ev_id();
 		if (count($ids) > 100)
 		{
-			$db = JFactory::getDBO();
+			$db = JFactory::getDbo();
 			$db->setQuery("SELECT * FROM #__jevents_exception where eventid IN (" . implode(",", $ids) . ")");
 			$rows = $db->loadObjectList();
 			foreach ($rows as $row)
@@ -61,7 +61,7 @@ if (!empty($this->icalEvents))
 	// mop up the last ones
 	if (count($ids) > 0)
 	{
-		$db = JFactory::getDBO();
+		$db = JFactory::getDbo();
 		$db->setQuery("SELECT * FROM #__jevents_exception where eventid IN (" . implode(",", $ids) . ")");
 		$rows = $db->loadObjectList();
 		foreach ($rows as $row)

--- a/component/site/views/modlatest/view.feed.php
+++ b/component/site/views/modlatest/view.feed.php
@@ -37,7 +37,7 @@ class ModlatestViewModlatest extends AdminICalRepeatViewICalRepeat
 		
 		$cfg = JEVConfig::getInstance();
 
-		$db	= JFactory::getDBO();
+		$db	= JFactory::getDbo();
 
 		// setup for all required function and classes
 		$file = JPATH_SITE . '/components/com_jevents/mod.defines.php';
@@ -60,7 +60,7 @@ class ModlatestViewModlatest extends AdminICalRepeatViewICalRepeat
 			. "\n AND m.id = ". $modid
 			. "\n AND m.access  " . (version_compare(JVERSION, '1.6.0', '>=') ? ' IN (' .  JEVHelper::getAid($user, 'string') . ')' : ' <=  ' .  JEVHelper::getAid($user))
 			. "\n AND m.client_id != 1";
-			$db	= JFactory::getDBO();
+			$db	= JFactory::getDbo();
 			$db->setQuery( $query );
 			$modules = $db->loadObjectList();
 			if (count($modules)<=0){

--- a/modules/mod_jevents_cal/tmpl/default/calendar.php
+++ b/modules/mod_jevents_cal/tmpl/default/calendar.php
@@ -70,7 +70,7 @@ class DefaultModCalView
 
 		$cfg = JEVConfig::getInstance();
 		$jev_component_name  = JEV_COM_COMPONENT;
-		$db	= JFactory::getDBO();
+		$db	= JFactory::getDbo();
 
 		$this->datamodel = new JEventsDataModel();
 
@@ -236,7 +236,7 @@ class DefaultModCalView
 
 	public function _displayCalendarMod($time, $startday, $linkString, &$day_name, $monthMustHaveEvent=false, $basedate=false){
 
-		$db	= JFactory::getDBO();
+		$db	= JFactory::getDbo();
 		$cfg = JEVConfig::getInstance();
 		$option = JEV_COM_COMPONENT;
 
@@ -447,7 +447,7 @@ class DefaultModCalView
 		}
 		$user = JFactory::getUser();
 
-		$db	= JFactory::getDBO();
+		$db	= JFactory::getDbo();
 
 		// this will get the viewname based on which classes have been implemented
 		$viewname = $this->getTheme();
@@ -503,7 +503,7 @@ class DefaultModCalView
 		}
 		$user = JFactory::getUser();
 
-		$db	= JFactory::getDBO();
+		$db	= JFactory::getDbo();
 
 		static $isloaded_css = false;
 		// this will get the viewname based on which classes have been implemented

--- a/modules/mod_jevents_cal/tmpl/default/calendar.php
+++ b/modules/mod_jevents_cal/tmpl/default/calendar.php
@@ -298,7 +298,7 @@ class DefaultModCalView
 
 		$month_name = JEVHelper::getMonthName($cal_month);
 		$first_of_month = JevDate::mktime(0,0,0,$cal_month, 1, $cal_year);
-		$today = JevDate::mktime(0,0,0,$cal_month, $cal_day, $cal_year);
+		$today = JevDate::mktime(0,0,0);
 
 		$content    = '';
 

--- a/modules/mod_jevents_cal/tmpl/ext/calendar.php
+++ b/modules/mod_jevents_cal/tmpl/ext/calendar.php
@@ -18,7 +18,7 @@ class ExtModCalView extends DefaultModCalView
 {
 
 	function _displayCalendarMod($time, $startday, $linkString,	&$day_name, $monthMustHaveEvent=false, $basedate=false){
-		$db	= JFactory::getDBO();
+		$db	= JFactory::getDbo();
 		$cfg = JEVConfig::getInstance();
 		$compname = JEV_COM_COMPONENT;
 

--- a/modules/mod_jevents_cal/tmpl/ext/calendar.php
+++ b/modules/mod_jevents_cal/tmpl/ext/calendar.php
@@ -85,7 +85,7 @@ class ExtModCalView extends DefaultModCalView
 
 		$month_name = JEVHelper::getMonthName($cal_month);
 		$to_day     = date("Y-m-d", $this->timeWithOffset);
-		$today = JevDate::mktime(0,0,0,$cal_month, $cal_day, $cal_year);
+		$today = JevDate::mktime(0,0,0);
 
 		$cal_prev_month 	= $cal_month - 1;
 		$cal_next_month 	= $cal_month + 1;

--- a/modules/mod_jevents_cal/tmpl/flat/calendar.php
+++ b/modules/mod_jevents_cal/tmpl/flat/calendar.php
@@ -16,7 +16,7 @@ defined ( '_JEXEC' ) or die ();
 include_once (JPATH_SITE . "/modules/mod_jevents_cal/tmpl/default/calendar.php");
 class FlatModCalView extends DefaultModCalView {
 	function _displayCalendarMod($time, $startday, $linkString, &$day_name, $monthMustHaveEvent = false, $basedate = false) {
-		$db = JFactory::getDBO ();
+		$db = JFactory::getDbo ();
 		$cfg = JEVConfig::getInstance ();
 		$compname = JEV_COM_COMPONENT;
 

--- a/modules/mod_jevents_cal/tmpl/flat/calendar.php
+++ b/modules/mod_jevents_cal/tmpl/flat/calendar.php
@@ -86,7 +86,7 @@ class FlatModCalView extends DefaultModCalView {
 
 		$month_name = JEVHelper::getMonthName ( $cal_month );
 		$to_day = date ( "Y-m-d", $this->timeWithOffset );
-		$today = JevDate::mktime ( 0, 0, 0, $cal_month, $cal_day, $cal_year );
+		$today = JevDate::mktime ( 0, 0, 0);
 
 		$cal_prev_month = $cal_month - 1;
 		$cal_next_month = $cal_month + 1;
@@ -197,6 +197,7 @@ class FlatModCalView extends DefaultModCalView {
 
 						$class = ($currentDay["cellDate"] == $today) ? "flatcal_todaycell" : "flatcal_daycell";
 						$linkclass = "flatcal_daylink";
+
 						if ($dayOfWeek == 0 && $currentDay["cellDate"] != $today) {
 							$class = "flatcal_sundaycell";
 							$linkclass = "flatcal_sundaylink";

--- a/modules/mod_jevents_latest/tmpl/default/latest.php
+++ b/modules/mod_jevents_latest/tmpl/default/latest.php
@@ -257,7 +257,7 @@ class DefaultModLatestView
 			$this->maxEvents = $limit;
 		}
 
-		$db = JFactory::getDBO();
+		$db = JFactory::getDbo();
 
 		$t_datenow = JEVHelper::getNow();
 		$this->now = $t_datenow->toUnix(true);

--- a/modules/mod_jevents_legend/tmpl/alternative/legend.php
+++ b/modules/mod_jevents_legend/tmpl/alternative/legend.php
@@ -38,7 +38,7 @@ class AlternativeModLegendView extends DefaultModLegendView{
 		$Itemid = $this->myItemid;
 		$user = JFactory::getUser();
 
-		$db	= JFactory::getDBO();
+		$db	= JFactory::getDbo();
 		// Parameters - This module should only be displayed alongside a com_jevents calendar component!!!
 		$cfg = JEVConfig::getInstance();
 

--- a/modules/mod_jevents_legend/tmpl/default/legend.php
+++ b/modules/mod_jevents_legend/tmpl/default/legend.php
@@ -83,7 +83,7 @@ class DefaultModLegendView
 		
 		$user =  JFactory::getUser();
 
-		$db = JFactory::getDBO();
+		$db = JFactory::getDbo();
 		// Parameters - This module should only be displayed alongside a com_jevents calendar component!!!
 		$cfg = JEVConfig::getInstance();
 
@@ -249,7 +249,7 @@ class DefaultModLegendView
 	protected function getCategoryHierarchy($catidList, $catidsGPList)
 	{
 
-		$db = JFactory::getDBO();
+		$db = JFactory::getDbo();
 		$aid = $this->datamodel->aid;
 		$user =  JFactory::getUser();
 

--- a/modules/mod_jevents_legend/tmpl/ext/legend.php
+++ b/modules/mod_jevents_legend/tmpl/ext/legend.php
@@ -37,7 +37,7 @@ class ExtModLegendView extends DefaultModLegendView{
 		$Itemid = $this->myItemid;
 		$user = JFactory::getUser();
 
-		$db	= JFactory::getDBO();
+		$db	= JFactory::getDbo();
 		// Parameters - This module should only be displayed alongside a com_jevents calendar component!!!
 		$cfg = JEVConfig::getInstance();
 

--- a/modules/mod_jevents_legend/tmpl/flat/legend.php
+++ b/modules/mod_jevents_legend/tmpl/flat/legend.php
@@ -37,7 +37,7 @@ class FlatModLegendView extends DefaultModLegendView{
 		$Itemid = $this->myItemid;
 		$user = JFactory::getUser();
 
-		$db	= JFactory::getDBO();
+		$db	= JFactory::getDbo();
 		// Parameters - This module should only be displayed alongside a com_jevents calendar component!!!
 		$cfg = JEVConfig::getInstance();
 

--- a/modules/mod_jevents_legend/tmpl/geraint/legend.php
+++ b/modules/mod_jevents_legend/tmpl/geraint/legend.php
@@ -38,7 +38,7 @@ class GeraintModLegendView extends DefaultModLegendView{
 		$Itemid = $this->myItemid;
 		$user = JFactory::getUser();
 
-		$db	= JFactory::getDBO();
+		$db	= JFactory::getDbo();
 		// Parameters - This module should only be displayed alongside a com_jevents calendar component!!!
 		$cfg = JEVConfig::getInstance();
 

--- a/plugins/search/eventsearch.php
+++ b/plugins/search/eventsearch.php
@@ -114,7 +114,7 @@ class plgSearchEventsearch extends JPlugin
 	function onSearch($text, $phrase = '', $ordering = '', $areas = null)
 	{
 
-		$db = JFactory::getDBO();
+		$db = JFactory::getDbo();
 		$user =  JFactory::getUser();
 		$groups = (version_compare(JVERSION, '1.6.0', '>=')) ? implode(',', $user->getAuthorisedViewLevels()) : false;
 


### PR DESCRIPTION
I can't see any valid reason for setting today for the day of the calendar from the current calendar data. We should be getting the fresh date of today. Issues happen when showing multiple calendar from different months, the 1st is always shown as 'Today' on a month which isn't this month. 

Solution, tell mktime to get todays date.