### PR TITLE
Fix for Today on minicalendar month when in future months.

### DIFF
--- a/modules/mod_jevents_cal/tmpl/default/calendar.php
+++ b/modules/mod_jevents_cal/tmpl/default/calendar.php
@@ -298,7 +298,7 @@ class DefaultModCalView
 
 		$month_name = JEVHelper::getMonthName($cal_month);
 		$first_of_month = JevDate::mktime(0,0,0,$cal_month, 1, $cal_year);
-		$today = JevDate::mktime(0,0,0,$cal_month, $cal_day, $cal_year);
+		$today = JevDate::mktime(0,0,0);
 
 		$content    = '';
 

--- a/modules/mod_jevents_cal/tmpl/ext/calendar.php
+++ b/modules/mod_jevents_cal/tmpl/ext/calendar.php
@@ -85,7 +85,7 @@ class ExtModCalView extends DefaultModCalView
 
 		$month_name = JEVHelper::getMonthName($cal_month);
 		$to_day     = date("Y-m-d", $this->timeWithOffset);
-		$today = JevDate::mktime(0,0,0,$cal_month, $cal_day, $cal_year);
+		$today = JevDate::mktime(0,0,0);
 
 		$cal_prev_month 	= $cal_month - 1;
 		$cal_next_month 	= $cal_month + 1;

--- a/modules/mod_jevents_cal/tmpl/flat/calendar.php
+++ b/modules/mod_jevents_cal/tmpl/flat/calendar.php
@@ -86,7 +86,7 @@ class FlatModCalView extends DefaultModCalView {
 
 		$month_name = JEVHelper::getMonthName ( $cal_month );
 		$to_day = date ( "Y-m-d", $this->timeWithOffset );
-		$today = JevDate::mktime ( 0, 0, 0, $cal_month, $cal_day, $cal_year );
+		$today = JevDate::mktime (0,0,0);
 
 		$cal_prev_month = $cal_month - 1;
 		$cal_next_month = $cal_month + 1;


### PR DESCRIPTION
No need to get this calendars current month data for the 'Today' data.