### PR TITLE
Mark (string) for comparison

### DIFF
--- a/component/site/libraries/helper.php
+++ b/component/site/libraries/helper.php
@@ -496,7 +496,7 @@ class JEVHelper
 		//Get the Params.
 		$params = JComponentHelper::getParams(JEV_COM_COMPONENT);
 
-		if ($params->get('menu-meta_description') && $jConfig->get('MetaDesc', '') === $document->getDescription())
+		if ($params->get('menu-meta_description') && (string) $jConfig->get('MetaDesc', '') === (string) $document->getDescription())
 		{
 			$document->setDescription($params->get('menu-meta_description'));
 		}


### PR DESCRIPTION
Since we are using strict operators we need to define as a string because $document->getDescription() returns NULL if there is no Meta.