### PR TITLE
add patch for remote completion bug twitter#1218

### DIFF
--- a/libraries/jevtypeahead/media/js/typeahead.bundle.js
+++ b/libraries/jevtypeahead/media/js/typeahead.bundle.js
@@ -1805,8 +1805,9 @@
                     suggestions = suggestions || [];
                     if (!canceled && rendered < that.limit) {
                         that.cancel = $.noop;
+                        suggestions = suggestions.slice(0, that.limit - rendered);
                         rendered += suggestions.length;
-                        that._append(query, suggestions.slice(0, that.limit - rendered));
+                        that._append(query, suggestions);
                         that.async && that.trigger("asyncReceived", query);
                     }
                 }


### PR DESCRIPTION
The typeahead library requires this change to correct patch for remote completion bug twitter#1218. Please see commit https://github.com/getyourguide/typeahead.js/commit/6fc8051fec273d0fa0c8a9340446aad07923c34c 

This change also needs to be applied to the typeahead.bundle.min.js file but I have not done so as I do not have the minify routine you are using. The change also needs to be applied to typeahead.jquery.js and its minified version.

The typeahead libraries shipped with JEvents are modified from the original so cannot simply be replaced.