### PR TITLE
Wrap call to importPlugin in output buffer and discard

### DIFF
--- a/component/site/views/default/helpers/defaultloadedfromtemplate.php
+++ b/component/site/views/default/helpers/defaultloadedfromtemplate.php
@@ -2314,7 +2314,9 @@ function DefaultLoadedFromTemplate($view, $template_name, $event, $mask, $templa
 	$tmprow         = new stdClass();
 	$tmprow->text   = $template_value;
 	$tmprow->event  = $event;
+	ob_start();
 	PluginHelper::importPlugin('content');
+	ob_end_clean();
 	$app->triggerEvent('onContentPrepare', array('com_jevents', &$tmprow, &$params, 0));
 	$template_value = $tmprow->text;
 	$template_value = str_replace("@£@", "@", $template_value);


### PR DESCRIPTION
The importPlugin call is outputting some text which is getting captured by the output buffer wrapping the call to this function. As a result the tickets are getting extraneous characters. Wrapping the importPlugin call with an output buffer and then discarding the buffer immediately after the call corrects the problem.

Presumably someone from the J1 team should fix importPlugin but I doubt very much priority would be placed on it.