### PR TITLE
Removed default value from first parameter

### DIFF
--- a/modules/mod_jevents_legend/tmpl/default/legend.php
+++ b/modules/mod_jevents_legend/tmpl/default/legend.php
@@ -28,7 +28,7 @@ class DefaultModLegendView
 	var $myItemid = 0;
 	var $myTask = null;
 
-	function __construct(&$params = null, $modid)
+	function __construct(&$params, $modid)
 	{
 
 		$this->_modid = $modid;


### PR DESCRIPTION
PHP:8
Deprecated: Required parameter $modid follows optional parameter $params in \modules\mod_jevents_legend\tmpl\default\legend.php on line 31