### PR TITLE
Changed the let and const keywords to var for older devices

### DIFF
--- a/component/site/assets/js/showon.js
+++ b/component/site/assets/js/showon.js
@@ -154,7 +154,7 @@ Joomla = window.Joomla || {};
             }
 
             try {
-                const showonChanged = new CustomEvent('gslshowon', {
+                var showonChanged = new CustomEvent('gslshowon', {
                     detail: {
                         name: 'showonChanged'
                     }

--- a/libraries/jevmodal/jevmodal.php
+++ b/libraries/jevmodal/jevmodal.php
@@ -288,9 +288,9 @@ function jevPopover(selector, container) {
 				// Fall back to native uikit
 				var hoveritems = document.querySelectorAll(selector);
 				hoveritems.forEach(function (hoveritem) {
-					let title = hoveritem.getAttribute('data-yspoptitle') || hoveritem.getAttribute('data-original-title') || hoveritem.getAttribute('title');
-					let body = hoveritem.getAttribute('data-yspopcontent') || hoveritem.getAttribute('data-content') || hoveritem.getAttribute('data-bs-content') || '';
-					let options = hoveritem.getAttribute('data-yspopoptions') || uikitoptions;
+					var title = hoveritem.getAttribute('data-yspoptitle') || hoveritem.getAttribute('data-original-title') || hoveritem.getAttribute('title');
+					var body = hoveritem.getAttribute('data-yspopcontent') || hoveritem.getAttribute('data-content') || hoveritem.getAttribute('data-bs-content') || '';
+					var options = hoveritem.getAttribute('data-yspopoptions') || uikitoptions;
 					if (typeof options == 'string') {
 						options = JSON.parse(options);
 					}


### PR DESCRIPTION
Older devices, particularly older iPads using older versions of safari do not support these javascript language constructs and hence fail when trying to render parts of JEvents and RSVP.