### PR TITLE
Fix ICAL export seperator error

### DIFF
--- a/component/site/controllers/icals.php
+++ b/component/site/controllers/icals.php
@@ -201,7 +201,8 @@ class ICalsController extends AdminIcalsController
 		$cats = JEVHelper::forceIntegerArray($cats, false);
 		if ($cats != array(0))
 		{
-			$input->set("catids", implode("|", $cats));
+			$separator = $params->get("catseparator", "|");
+			$input->set("catids", implode($separator, $cats));
 		}
 		else
 		{
@@ -213,7 +214,6 @@ class ICalsController extends AdminIcalsController
 		// All years
 		if ($years == 0)
 		{
-			$params = ComponentHelper::getParams(JEV_COM_COMPONENT);
 			$years  = array();
 			for ($y = JEVHelper::getMinYear(); $y <= JEVHelper::getMaxYear(); $y++)
 			{


### PR DESCRIPTION
Selecting categories for ical export does only export the first category.